### PR TITLE
Converted all async code into Context-Free code, using ConfigureAwait

### DIFF
--- a/IntegrationTests/ConnectionSpec.cs
+++ b/IntegrationTests/ConnectionSpec.cs
@@ -31,7 +31,8 @@ namespace IntegrationTests
 				var client = this.GetClient ();
 
 				clients.Add (client);
-				await client.ConnectAsync (new ClientCredentials (this.GetClientId ()));
+				await client.ConnectAsync (new ClientCredentials (this.GetClientId ()))
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 
 			Assert.True (clients.All(c => c.IsConnected));
@@ -52,11 +53,13 @@ namespace IntegrationTests
 				var client = this.GetClient ();
 
 				clients.Add (client);
-				await client.ConnectAsync (new ClientCredentials (this.GetClientId ()));
+				await client.ConnectAsync (new ClientCredentials (this.GetClientId ()))
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 
 			foreach (var client in clients) {
-				await client.DisconnectAsync ();
+				await client.DisconnectAsync ()
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 
 			Assert.True (clients.All(c => !c.IsConnected));
@@ -72,12 +75,14 @@ namespace IntegrationTests
 		{
 			var client = this.GetClient ();
 
-			await client.ConnectAsync (new ClientCredentials (this.GetClientId ()));
+			await client.ConnectAsync (new ClientCredentials (this.GetClientId ()))
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			var clientId = client.Id;
 			var existClientAfterConnect = this.server.ActiveClients.Any (c => c == clientId);
 
-			await client.DisconnectAsync ();
+			await client.DisconnectAsync ()
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			var clientClosed = new ManualResetEventSlim ();
 

--- a/IntegrationTests/ConnectionSpecWithKeepAlive.cs
+++ b/IntegrationTests/ConnectionSpecWithKeepAlive.cs
@@ -27,7 +27,8 @@ namespace IntegrationTests
 		{
 			var client = this.GetClient ();
 
-			await client.ConnectAsync (new ClientCredentials (this.GetClientId ()));
+			await client.ConnectAsync (new ClientCredentials (this.GetClientId ()))
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			var clientId = client.Id;
 			var existClientAfterConnect = this.server.ActiveClients.Any (c => c == clientId);
@@ -77,7 +78,8 @@ namespace IntegrationTests
 				var client = this.GetClient ();
 
 				clients.Add (client);
-				await client.ConnectAsync (new ClientCredentials (this.GetClientId ()));
+				await client.ConnectAsync (new ClientCredentials (this.GetClientId ()))
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 
 			Thread.Sleep (TimeSpan.FromSeconds(this.keepAliveSecs * 3));

--- a/IntegrationTests/ExceptionSpec.cs
+++ b/IntegrationTests/ExceptionSpec.cs
@@ -26,7 +26,8 @@ namespace IntegrationTests
 			var server = this.GetServer ();
 			var client = this.GetClient ();
 
-			await client.ConnectAsync (new ClientCredentials(this.GetClientId()));
+			await client.ConnectAsync (new ClientCredentials(this.GetClientId()))
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			server.Stop ();
 

--- a/IntegrationTests/PublishingSpec.cs
+++ b/IntegrationTests/PublishingSpec.cs
@@ -35,7 +35,8 @@ namespace IntegrationTests
 					Payload = Serializer.Serialize(testMessage)
 				};
 
-				await client.PublishAsync (message, QualityOfService.AtMostOnce);
+				await client.PublishAsync (message, QualityOfService.AtMostOnce)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 
 			Assert.True (client.IsConnected);
@@ -59,7 +60,8 @@ namespace IntegrationTests
 					Payload = Serializer.Serialize(testMessage)
 				};
 
-				await client.PublishAsync (message, QualityOfService.AtLeastOnce);
+				await client.PublishAsync (message, QualityOfService.AtLeastOnce)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 
 			Assert.True (client.IsConnected);
@@ -82,7 +84,8 @@ namespace IntegrationTests
 					Payload = Serializer.Serialize(testMessage)
 				};
 
-				await client.PublishAsync (message, Hermes.Packets.QualityOfService.ExactlyOnce);
+				await client.PublishAsync (message, Hermes.Packets.QualityOfService.ExactlyOnce)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 
 			Assert.True (client.IsConnected);
@@ -107,8 +110,10 @@ namespace IntegrationTests
 			var subscriber1Received = 0;
 			var subscriber2Received = 0;
 
-			await subscriber1.SubscribeAsync (topicFilter, QualityOfService.AtMostOnce);
-			await subscriber2.SubscribeAsync (topicFilter, QualityOfService.AtMostOnce);
+			await subscriber1.SubscribeAsync (topicFilter, QualityOfService.AtMostOnce)
+				.ConfigureAwait(continueOnCapturedContext: false);
+			await subscriber2.SubscribeAsync (topicFilter, QualityOfService.AtMostOnce)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			subscriber1.Receiver
 				.Subscribe (m => {
@@ -138,7 +143,8 @@ namespace IntegrationTests
 					Payload = Serializer.Serialize(testMessage)
 				};
 
-				await publisher.PublishAsync (message, QualityOfService.AtMostOnce);
+				await publisher.PublishAsync (message, QualityOfService.AtMostOnce)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 
 			var completed = WaitHandle.WaitAll (new WaitHandle[] { subscriber1Done.WaitHandle, subscriber2Done.WaitHandle }, TimeSpan.FromSeconds(this.Configuration.WaitingTimeoutSecs));
@@ -178,7 +184,8 @@ namespace IntegrationTests
 					Payload = Serializer.Serialize(testMessage)
 				};
 
-				await publisher.PublishAsync (message, QualityOfService.AtMostOnce);
+				await publisher.PublishAsync (message, QualityOfService.AtMostOnce)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 
 			var success = topicsNotSubscribedDone.Wait (TimeSpan.FromSeconds(this.keepAliveSecs));
@@ -203,8 +210,10 @@ namespace IntegrationTests
 			var subscriberDone = new ManualResetEventSlim ();
 			var subscriberReceived = 0;
 
-			await subscriber.SubscribeAsync (requestTopic, QualityOfService.AtMostOnce);
-			await publisher.SubscribeAsync (responseTopic, QualityOfService.AtMostOnce);
+			await subscriber.SubscribeAsync (requestTopic, QualityOfService.AtMostOnce)
+				.ConfigureAwait(continueOnCapturedContext: false);
+			await publisher.SubscribeAsync (responseTopic, QualityOfService.AtMostOnce)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			subscriber.Receiver
 				.Subscribe (async m => {
@@ -216,7 +225,8 @@ namespace IntegrationTests
 							Payload = Serializer.Serialize(response)
 						};
 
-						await subscriber.PublishAsync (message, QualityOfService.AtMostOnce);
+						await subscriber.PublishAsync (message, QualityOfService.AtMostOnce)
+							.ConfigureAwait(continueOnCapturedContext: false);
 					}
 				});
 
@@ -238,7 +248,8 @@ namespace IntegrationTests
 					Payload = Serializer.Serialize(request)
 				};
 
-				await publisher.PublishAsync (message, QualityOfService.AtMostOnce);
+				await publisher.PublishAsync (message, QualityOfService.AtMostOnce)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 
 			var completed = subscriberDone.Wait (TimeSpan.FromSeconds (this.Configuration.WaitingTimeoutSecs));

--- a/IntegrationTests/SubscriptionSpec.cs
+++ b/IntegrationTests/SubscriptionSpec.cs
@@ -23,7 +23,8 @@ namespace IntegrationTests
 			var client = this.GetClient ();
 			var topicFilter = "test/topic1/*";
 
-			await client.SubscribeAsync (topicFilter, QualityOfService.AtMostOnce);
+			await client.SubscribeAsync (topicFilter, QualityOfService.AtMostOnce)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.True (client.IsConnected);
 		}
@@ -37,7 +38,8 @@ namespace IntegrationTests
 			for (var i = 1; i <= topicsToSubscribe; i++) {
 				var topicFilter = string.Format ("test/topic{0}", i);
 
-				await client.SubscribeAsync (topicFilter, QualityOfService.AtMostOnce);
+				await client.SubscribeAsync (topicFilter, QualityOfService.AtMostOnce)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 
 			Assert.True (client.IsConnected);
@@ -56,10 +58,12 @@ namespace IntegrationTests
 				var topicFilter = string.Format ("test/topic{0}", i);
 
 				topics.Add (topicFilter);
-				await client.SubscribeAsync (topicFilter, QualityOfService.AtMostOnce);
+				await client.SubscribeAsync (topicFilter, QualityOfService.AtMostOnce)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 
-			await client.UnsubscribeAsync (topics.ToArray());
+			await client.UnsubscribeAsync (topics.ToArray())
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.True (client.IsConnected);
 

--- a/src/Client/Client.cs
+++ b/src/Client/Client.cs
@@ -96,7 +96,8 @@ namespace Hermes
 		/// <exception cref="ClientException">ClientException</exception>
 		public async Task ConnectAsync (ClientCredentials credentials, bool cleanSession = false)
 		{
-			await this.ConnectAsync (credentials, null, cleanSession);
+			await this.ConnectAsync (credentials, null, cleanSession)
+				.ConfigureAwait(continueOnCapturedContext: false);
 		}
 
 		/// <exception cref="ClientException">ClientException</exception>
@@ -119,7 +120,8 @@ namespace Hermes
 			var connectTimeout = TimeSpan.FromSeconds (this.configuration.WaitingTimeoutSecs);
 
 			try {
-				await this.SendPacket (connect);
+				await this.SendPacket (connect)
+					.ConfigureAwait(continueOnCapturedContext: false);
 
 				ack = await this.packetListener.Packets
 					.OfType<ConnectAck> ()
@@ -159,7 +161,8 @@ namespace Hermes
 			var subscribeTimeout = TimeSpan.FromSeconds(this.configuration.WaitingTimeoutSecs);
 
 			try {
-				await this.SendPacket (subscribe);
+				await this.SendPacket (subscribe)
+					.ConfigureAwait(continueOnCapturedContext: false);
 
 				ack = await this.packetListener.Packets
 					.OfType<SubscribeAck> ()
@@ -203,7 +206,8 @@ namespace Hermes
 			var senderFlow = this.flowProvider.GetFlow<PublishSenderFlow> ();
 
 			try {
-				await senderFlow.SendPublishAsync (this.Id, publish, this.packetChannel);
+				await senderFlow.SendPublishAsync (this.Id, publish, this.packetChannel)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			} catch (Exception ex) {
 				this.Close (ex);
 				throw;
@@ -223,7 +227,8 @@ namespace Hermes
 			var unsubscribeTimeout = TimeSpan.FromSeconds(this.configuration.WaitingTimeoutSecs);
 
 			try {
-				await this.SendPacket (unsubscribe);
+				await this.SendPacket (unsubscribe)
+					.ConfigureAwait(continueOnCapturedContext: false);
 
 				ack = await this.packetListener.Packets
 					.OfType<UnsubscribeAck> ()
@@ -267,9 +272,9 @@ namespace Hermes
 			var disconnect = new Disconnect ();
 
 			try {
-				await this.SendPacket (disconnect).ContinueWith(t => {
-					this.Close (ClosedReason.Disconnect);
-				});
+				await this.SendPacket (disconnect)
+					.ContinueWith(t => this.Close (ClosedReason.Disconnect))
+					.ConfigureAwait(continueOnCapturedContext: false);
 			} catch (Exception ex) {
 				this.Close (ex);
 				throw;
@@ -359,7 +364,8 @@ namespace Hermes
 		{
 			this.sender.OnNext (packet);
 
-			await this.packetChannel.SendAsync (packet);
+			await this.packetChannel.SendAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 		}
 
 		private void CheckUnderlyingConnection ()

--- a/src/Client/ClientPacketListener.cs
+++ b/src/Client/ClientPacketListener.cs
@@ -58,7 +58,8 @@ namespace Hermes
 						return;
 					}
 
-					await this.DispatchPacketAsync (packet, clientId, channel);
+					await this.DispatchPacketAsync (packet, clientId, channel)
+						.ConfigureAwait(continueOnCapturedContext: false);
 				}, ex => {
 					this.NotifyError (ex);
 				});
@@ -66,7 +67,8 @@ namespace Hermes
 			this.nextPacketsSubscription = channel.Receiver
 				.Skip(1)
 				.Subscribe (async packet => {
-					await this.DispatchPacketAsync (packet, clientId, channel);
+					await this.DispatchPacketAsync (packet, clientId, channel)
+						.ConfigureAwait(continueOnCapturedContext: false);
 				}, ex => {
 					this.NotifyError (ex);
 				});
@@ -129,7 +131,8 @@ namespace Hermes
 
 					var ping = new PingRequest ();
 
-					await channel.SendAsync (ping);
+					await channel.SendAsync (ping)
+						.ConfigureAwait(continueOnCapturedContext: false);
 				} catch (Exception ex) {
 					this.NotifyError (ex);
 				}
@@ -151,7 +154,8 @@ namespace Hermes
 
 					this.packets.OnNext (packet);
 
-					await flow.ExecuteAsync (clientId, packet, channel);
+					await flow.ExecuteAsync (clientId, packet, channel)
+						.ConfigureAwait(continueOnCapturedContext: false);
 				} catch (Exception ex) {
 					this.NotifyError (ex);
 				}

--- a/src/Client/Flows/ClientConnectFlow.cs
+++ b/src/Client/Flows/ClientConnectFlow.cs
@@ -29,8 +29,10 @@ namespace Hermes.Flows
 				throw new ProtocolException (string.Format (Resources.SessionRepository_ClientSessionNotFound, clientId));
 			}
 
-			await this.SendPendingMessagesAsync (session, channel);
-			await this.SendPendingAcknowledgementsAsync (session, channel);
+			await this.SendPendingMessagesAsync (session, channel)
+				.ConfigureAwait(continueOnCapturedContext: false);
+			await this.SendPendingAcknowledgementsAsync (session, channel)
+				.ConfigureAwait(continueOnCapturedContext: false);
 		}
 
 		private async Task SendPendingMessagesAsync(ClientSession session, IChannel<IPacket> channel)
@@ -39,7 +41,9 @@ namespace Hermes.Flows
 				var publish = new Publish(pendingMessage.Topic, pendingMessage.QualityOfService, 
 					pendingMessage.Retain, pendingMessage.Duplicated, pendingMessage.PacketId);
 
-				await this.senderFlow.SendPublishAsync (session.ClientId, publish, channel, PendingMessageStatus.PendingToAcknowledge);
+				await this.senderFlow
+					.SendPublishAsync (session.ClientId, publish, channel, PendingMessageStatus.PendingToAcknowledge)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 		}
 
@@ -54,7 +58,8 @@ namespace Hermes.Flows
 					ack = new PublishRelease (pendingAcknowledgement.PacketId);
 				}
 
-				await this.senderFlow.SendAckAsync (session.ClientId, ack, channel);
+				await this.senderFlow.SendAckAsync (session.ClientId, ack, channel)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 		}
 	}

--- a/src/Core/Flows/PingFlow.cs
+++ b/src/Core/Flows/PingFlow.cs
@@ -11,7 +11,8 @@ namespace Hermes.Flows
 				return;
 			}
 
-			await channel.SendAsync(new PingResponse());
+			await channel.SendAsync(new PingResponse())
+				.ConfigureAwait(continueOnCapturedContext: false);
 		}
 	}
 }

--- a/src/Core/Flows/PublishFlow.cs
+++ b/src/Core/Flows/PublishFlow.cs
@@ -38,12 +38,15 @@ namespace Hermes.Flows
 				return;
 			}
 
-			await channel.SendAsync (ack);
+			await channel.SendAsync (ack)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			if(ack.Type == PacketType.PublishReceived) {
-				await this.MonitorAckAsync<PublishRelease> (ack, clientId, channel);
+				await this.MonitorAckAsync<PublishRelease> (ack, clientId, channel)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			} else if (ack.Type == PacketType.PublishRelease) {
-				await this.MonitorAckAsync<PublishComplete> (ack, clientId, channel);
+				await this.MonitorAckAsync<PublishComplete> (ack, clientId, channel)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 		}
 
@@ -80,7 +83,8 @@ namespace Hermes.Flows
 				tracer.Warn (Resources.Tracer_PublishFlow_RetryingQoSFlow, sentMessage.Type, clientId);
 
 				try {
-					await channel.SendAsync (sentMessage);
+					await channel.SendAsync (sentMessage)
+						.ConfigureAwait(continueOnCapturedContext: false);
 				} catch (Exception ex) {
 					qosTimer.Stop ();
 					ackSubject.OnError (ex);

--- a/src/Core/Flows/PublishReceiverFlow.cs
+++ b/src/Core/Flows/PublishReceiverFlow.cs
@@ -26,11 +26,13 @@ namespace Hermes.Flows
 			if (input.Type == PacketType.Publish) {
 				var publish = input as Publish;
 
-				await this.HandlePublishAsync (clientId, publish, channel);
+				await this.HandlePublishAsync (clientId, publish, channel)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			} else if (input.Type == PacketType.PublishRelease) {
 				var publishRelease = input as PublishRelease;
 
-				await this.HandlePublishReleaseAsync (clientId, publishRelease, channel);
+				await this.HandlePublishReleaseAsync (clientId, publishRelease, channel)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 		}
 
@@ -59,20 +61,24 @@ namespace Hermes.Flows
 			if(qos == QualityOfService.ExactlyOnce && 
 				session.PendingAcknowledgements.ToList()
 					.Any(ack => ack.Type == PacketType.PublishReceived && ack.PacketId == publish.PacketId.Value)) {
-				await this.SendQosAck (clientId, qos, publish, channel);
+				await this.SendQosAck (clientId, qos, publish, channel)
+					.ConfigureAwait(continueOnCapturedContext: false);
 
 				return;
 			}
 
-			await this.ProcessPublishAsync(publish, clientId);
-			await this.SendQosAck (clientId, qos, publish, channel);
+			await this.ProcessPublishAsync(publish, clientId)
+				.ConfigureAwait(continueOnCapturedContext: false);
+			await this.SendQosAck (clientId, qos, publish, channel)
+				.ConfigureAwait(continueOnCapturedContext: false);
 		}
 
 		private async Task HandlePublishReleaseAsync(string clientId, PublishRelease publishRelease, IChannel<IPacket> channel)
 		{
 			this.RemovePendingAcknowledgement (clientId, publishRelease.PacketId, PacketType.PublishReceived);
 
-			await this.SendAckAsync (clientId, new PublishComplete (publishRelease.PacketId), channel);
+			await this.SendAckAsync (clientId, new PublishComplete (publishRelease.PacketId), channel)
+				.ConfigureAwait(continueOnCapturedContext: false);
 		}
 
 		private async Task SendQosAck(string clientId, QualityOfService qos, Publish publish, IChannel<IPacket> channel)
@@ -80,9 +86,11 @@ namespace Hermes.Flows
 			if (qos == QualityOfService.AtMostOnce) {
 				return;
 			} else if (qos == QualityOfService.AtLeastOnce) {
-				await this.SendAckAsync (clientId, new PublishAck (publish.PacketId.Value), channel);
+				await this.SendAckAsync (clientId, new PublishAck (publish.PacketId.Value), channel)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			} else {
-				await this.SendAckAsync (clientId, new PublishReceived (publish.PacketId.Value), channel);
+				await this.SendAckAsync (clientId, new PublishReceived (publish.PacketId.Value), channel)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 		}
 	}

--- a/src/Core/Flows/PublishSenderFlow.cs
+++ b/src/Core/Flows/PublishSenderFlow.cs
@@ -42,7 +42,8 @@ namespace Hermes.Flows
 			var ackPacket = senderRule (clientId, flowPacket.PacketId);
 
 			if (ackPacket != default(IFlowPacket)) {
-				await this.SendAckAsync (clientId, ackPacket, channel);
+				await this.SendAckAsync (clientId, ackPacket, channel)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 		}
 
@@ -59,12 +60,15 @@ namespace Hermes.Flows
 				this.SaveMessage (message, clientId, PendingMessageStatus.PendingToAcknowledge);
 			}
 
-			await channel.SendAsync (message);
+			await channel.SendAsync (message)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			if(qos == QualityOfService.AtLeastOnce) {
-				await this.MonitorAckAsync<PublishAck> (message, clientId, channel);
+				await this.MonitorAckAsync<PublishAck> (message, clientId, channel)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			} else if (qos == QualityOfService.ExactlyOnce) {
-				await this.MonitorAckAsync<PublishReceived> (message, clientId, channel);
+				await this.MonitorAckAsync<PublishReceived> (message, clientId, channel)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 		}
 
@@ -106,7 +110,8 @@ namespace Hermes.Flows
 						};
 
 				try {
-					await channel.SendAsync (duplicated);
+					await channel.SendAsync (duplicated)
+						.ConfigureAwait(continueOnCapturedContext: false);
 				} catch (Exception ex) {
 					qosTimer.Stop ();
 					ackSubject.OnError (ex);

--- a/src/Core/Formatters/Formatter.cs
+++ b/src/Core/Formatters/Formatter.cs
@@ -27,7 +27,8 @@ namespace Hermes.Formatters
 				throw new ProtocolException (error);
 			}
 
-			var packet = await Task.Run(() => this.Read (bytes));
+			var packet = await Task.Run(() => this.Read (bytes))
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			return packet;
 		}
@@ -43,7 +44,8 @@ namespace Hermes.Formatters
 				throw new ProtocolException (error);
 			}
 
-			var bytes = await Task.Run(() => this.Write (packet as T));
+			var bytes = await Task.Run(() => this.Write (packet as T))
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			return bytes;
 		}

--- a/src/Core/PacketChannel.cs
+++ b/src/Core/PacketChannel.cs
@@ -25,7 +25,8 @@ namespace Hermes
 			this.subscription = innerChannel.Receiver
 				.Subscribe (async bytes => {
 					try {
-						var packet = await this.manager.GetPacketAsync (bytes);
+						var packet = await this.manager.GetPacketAsync (bytes)
+							.ConfigureAwait(continueOnCapturedContext: false);
 
 						this.receiver.OnNext (packet);
 					} catch (ProtocolException ex) {
@@ -46,11 +47,13 @@ namespace Hermes
 				throw new ObjectDisposedException (this.GetType ().FullName);
 			}
 
-			var bytes = await this.manager.GetBytesAsync (packet);
+			var bytes = await this.manager.GetBytesAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			this.sender.OnNext (packet);
 
-			await this.innerChannel.SendAsync (bytes);
+			await this.innerChannel.SendAsync (bytes)
+				.ConfigureAwait(continueOnCapturedContext: false);
 		}
 
 		public void Dispose ()

--- a/src/Core/PacketManager.cs
+++ b/src/Core/PacketManager.cs
@@ -32,7 +32,8 @@ namespace Hermes
 			if (!formatters.TryGetValue(packetType, out formatter))
 				throw new ProtocolException (Resources.PacketManager_PacketUnknown);
 
-			var packet = await formatter.FormatAsync (bytes);
+			var packet = await formatter.FormatAsync (bytes)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			return packet;
 		}
@@ -47,7 +48,8 @@ namespace Hermes
 			if (!formatters.TryGetValue(packet.Type, out formatter))
 				throw new ProtocolException (Resources.PacketManager_PacketUnknown);
 
-			var bytes = await formatter.FormatAsync (packet);
+			var bytes = await formatter.FormatAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			return bytes;
 		}

--- a/src/Server/Flows/ServerConnectFlow.cs
+++ b/src/Server/Flows/ServerConnectFlow.cs
@@ -47,8 +47,10 @@ namespace Hermes.Flows
 
 				tracer.Info (Resources.Tracer_Server_CreatedSession, clientId);
 			} else {
-				await this.SendPendingMessagesAsync (session, channel);
-				await this.SendPendingAcknowledgementsAsync (session, channel);
+				await this.SendPendingMessagesAsync (session, channel)
+					.ConfigureAwait(continueOnCapturedContext: false);
+				await this.SendPendingAcknowledgementsAsync (session, channel)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 
 			if (connect.Will != null) {
@@ -57,7 +59,8 @@ namespace Hermes.Flows
 				this.willRepository.Create (connectionWill);
 			}
 
-			await channel.SendAsync(new ConnectAck (ConnectionStatus.Accepted, sessionPresent));
+			await channel.SendAsync(new ConnectAck (ConnectionStatus.Accepted, sessionPresent))
+				.ConfigureAwait(continueOnCapturedContext: false);
 		}
 
 		private async Task SendPendingMessagesAsync(ClientSession session, IChannel<IPacket> channel)
@@ -72,9 +75,11 @@ namespace Hermes.Flows
 					session.PendingMessages.Remove (pendingMessage);
 					this.sessionRepository.Update (session);
 
-					await this.senderFlow.SendPublishAsync (session.ClientId, publish, channel);
+					await this.senderFlow.SendPublishAsync (session.ClientId, publish, channel)
+						.ConfigureAwait(continueOnCapturedContext: false);
 				} else {
-					await this.senderFlow.SendPublishAsync (session.ClientId, publish, channel, PendingMessageStatus.PendingToAcknowledge);
+					await this.senderFlow.SendPublishAsync (session.ClientId, publish, channel, PendingMessageStatus.PendingToAcknowledge)
+						.ConfigureAwait(continueOnCapturedContext: false);
 				}
 			}
 		}
@@ -91,7 +96,8 @@ namespace Hermes.Flows
 				else if(pendingAcknowledgement.Type == PacketType.PublishRelease)
 					ack = new PublishRelease (pendingAcknowledgement.PacketId);
 
-				await this.senderFlow.SendAckAsync (session.ClientId, ack, channel, PendingMessageStatus.PendingToAcknowledge);
+				await this.senderFlow.SendAckAsync (session.ClientId, ack, channel, PendingMessageStatus.PendingToAcknowledge)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			}
 		}
 	}

--- a/src/Server/Flows/ServerPublishReceiverFlow.cs
+++ b/src/Server/Flows/ServerPublishReceiverFlow.cs
@@ -53,7 +53,8 @@ namespace Hermes.Flows
 				}
 			}
 
-			await this.DispatchAsync (publish, clientId);
+			await this.DispatchAsync (publish, clientId)
+				.ConfigureAwait(continueOnCapturedContext: false);
 		}
 
 		private async Task DispatchAsync (Publish publish, string clientId)
@@ -68,7 +69,8 @@ namespace Hermes.Flows
 				this.eventStream.Push (new TopicNotSubscribed { Topic = publish.Topic, SenderId = clientId, Payload = publish.Payload });
 			} else {
 				foreach (var subscription in subscriptions) {
-					await this.DispatchAsync (subscription, publish);
+					await this.DispatchAsync (subscription, publish)
+						.ConfigureAwait(continueOnCapturedContext: false);
 				}
 			}
 		}
@@ -82,7 +84,8 @@ namespace Hermes.Flows
 			};
 			var clientChannel = this.connectionProvider.GetConnection (subscription.ClientId);
 
-			await this.senderFlow.SendPublishAsync (subscription.ClientId, subscriptionPublish, clientChannel);
+			await this.senderFlow.SendPublishAsync (subscription.ClientId, subscriptionPublish, clientChannel)
+				.ConfigureAwait(continueOnCapturedContext: false);
 		}
 	}
 }

--- a/src/Server/Flows/ServerSubscribeFlow.cs
+++ b/src/Server/Flows/ServerSubscribeFlow.cs
@@ -73,7 +73,8 @@ namespace Hermes.Flows
 						session.Subscriptions.Add (clientSubscription);
 					}
 
-					await this.SendRetainedMessagesAsync (clientSubscription, channel);
+					await this.SendRetainedMessagesAsync (clientSubscription, channel)
+						.ConfigureAwait(continueOnCapturedContext: false);
 		
 					var supportedQos = configuration.GetSupportedQos(subscription.MaximumQualityOfService);
 					var returnCode = supportedQos.ToReturnCode ();
@@ -88,7 +89,8 @@ namespace Hermes.Flows
 
 			this.sessionRepository.Update (session);
 
-			await channel.SendAsync(new SubscribeAck (subscribe.PacketId, returnCodes.ToArray()));
+			await channel.SendAsync(new SubscribeAck (subscribe.PacketId, returnCodes.ToArray()))
+				.ConfigureAwait(continueOnCapturedContext: false);
 		}
 
 		private async Task SendRetainedMessagesAsync(ClientSubscription subscription, IChannel<IPacket> channel)
@@ -105,7 +107,8 @@ namespace Hermes.Flows
 						Payload = retainedMessage.Payload
 					};
 
-					await this.senderFlow.SendPublishAsync(subscription.ClientId, publish, channel);
+					await this.senderFlow.SendPublishAsync(subscription.ClientId, publish, channel)
+						.ConfigureAwait(continueOnCapturedContext: false);
 				}
 			}
 		}

--- a/src/Server/Flows/ServerUnsubscribeFlow.cs
+++ b/src/Server/Flows/ServerUnsubscribeFlow.cs
@@ -38,7 +38,8 @@ namespace Hermes.Flows
 
 			this.sessionRepository.Update(session);
 
-			await channel.SendAsync(new UnsubscribeAck (unsubscribe.PacketId));
+			await channel.SendAsync(new UnsubscribeAck (unsubscribe.PacketId))
+				.ConfigureAwait(continueOnCapturedContext: false);
 		}
 	}
 }

--- a/src/Server/ServerPacketListener.cs
+++ b/src/Server/ServerPacketListener.cs
@@ -69,9 +69,11 @@ namespace Hermes
 
 					tracer.Info (Resources.Tracer_ServerPacketListener_ConnectPacketReceived, clientId);
 
-					await this.DispatchPacketAsync (connect, clientId, channel);
+					await this.DispatchPacketAsync (connect, clientId, channel)
+						.ConfigureAwait(continueOnCapturedContext: false);
 				}, async ex => {
-					await this.HandleConnectionExceptionAsync (ex, channel);
+					await this.HandleConnectionExceptionAsync (ex, channel)
+						.ConfigureAwait(continueOnCapturedContext: false);
 				});
 
 			this.nextPacketsSubscription = channel.Receiver
@@ -82,7 +84,8 @@ namespace Hermes
 						return;
 					}
 
-					await this.DispatchPacketAsync (packet, clientId, channel);
+					await this.DispatchPacketAsync (packet, clientId, channel)
+						.ConfigureAwait(continueOnCapturedContext: false);
 				}, ex => {
 					this.NotifyError (ex, clientId);
 				});
@@ -138,7 +141,8 @@ namespace Hermes
 				var errorAck = new ConnectAck (connectEx.ReturnCode, existingSession: false);
 
 				try {
-					await channel.SendAsync (errorAck);
+					await channel.SendAsync (errorAck)
+						.ConfigureAwait(continueOnCapturedContext: false);
 				} catch (Exception ex) {
 					this.NotifyError (ex);
 				}
@@ -186,7 +190,8 @@ namespace Hermes
 
 					this.packets.OnNext (packet);
 
-					await flow.ExecuteAsync (clientId, packet, channel);
+					await flow.ExecuteAsync (clientId, packet, channel)
+						.ConfigureAwait(continueOnCapturedContext: false);
 				} catch (Exception ex) {
 					this.NotifyError (ex, clientId);
 				}

--- a/src/Server/TcpChannel.cs
+++ b/src/Server/TcpChannel.cs
@@ -69,7 +69,9 @@ namespace Hermes
 			try {
 				tracer.Info (Resources.Tracer_TcpChannel_SendingPacket, message.Length);
 
-				await this.client.GetStream ().WriteAsync(message, 0, message.Length);
+				await this.client.GetStream ()
+					.WriteAsync(message, 0, message.Length)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			} catch (ObjectDisposedException disposedEx) {
 				throw new ProtocolException (Resources.TcpChannel_SocketDisconnected, disposedEx);
 			}

--- a/src/Tests/Flows/ConnectFlowSpec.cs
+++ b/src/Tests/Flows/ConnectFlowSpec.cs
@@ -36,7 +36,8 @@ namespace Tests.Flows
 
 			var flow = new ServerConnectFlow (sessionRepository.Object, willRepository.Object, senderFlow.Object);
 
-			await flow.ExecuteAsync (clientId, connect, channel.Object);
+			await flow.ExecuteAsync (clientId, connect, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			sessionRepository.Verify (r => r.Create (It.Is<ClientSession> (s => s.ClientId == clientId && s.Clean == true)));
 			sessionRepository.Verify (r => r.Delete (It.IsAny<Expression<Func<ClientSession, bool>>> ()), Times.Never);
@@ -82,7 +83,8 @@ namespace Tests.Flows
 
 			var flow = new ServerConnectFlow (sessionRepository.Object, willRepository.Object, senderFlow.Object);
 
-			await flow.ExecuteAsync (clientId, connect, channel.Object);
+			await flow.ExecuteAsync (clientId, connect, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			sessionRepository.Verify (r => r.Create (It.IsAny<ClientSession> ()), Times.Never);
 			sessionRepository.Verify (r => r.Delete (It.IsAny<Expression<Func<ClientSession, bool>>> ()), Times.Never);
@@ -126,7 +128,8 @@ namespace Tests.Flows
 
 			var flow = new ServerConnectFlow (sessionRepository.Object, willRepository.Object, senderFlow.Object);
 
-			await flow.ExecuteAsync (clientId, connect, channel.Object);
+			await flow.ExecuteAsync (clientId, connect, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			var connectAck = sentPacket as ConnectAck;
 
@@ -169,7 +172,8 @@ namespace Tests.Flows
 
 			var flow = new ServerConnectFlow (sessionRepository.Object, willRepository.Object, senderFlow.Object);
 
-			await flow.ExecuteAsync (clientId, connect, channel.Object);
+			await flow.ExecuteAsync (clientId, connect, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			var connectAck = sentPacket as ConnectAck;
 
@@ -206,7 +210,8 @@ namespace Tests.Flows
 
 			var flow = new ServerConnectFlow (sessionRepository.Object, willRepository.Object, senderFlow.Object);
 
-			await flow.ExecuteAsync (clientId, connect, channel.Object);
+			await flow.ExecuteAsync (clientId, connect, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			var connectAck = sentPacket as ConnectAck;
 

--- a/src/Tests/Flows/DisconnectFlowSpec.cs
+++ b/src/Tests/Flows/DisconnectFlowSpec.cs
@@ -37,7 +37,8 @@ namespace Tests.Flows
 
 			sessionRepository.Setup(r => r.Get(It.IsAny<Expression<Func<ClientSession, bool>>>())).Returns(session);
 
-			await flow.ExecuteAsync (clientId, disconnect, channel.Object);
+			await flow.ExecuteAsync (clientId, disconnect, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			connectionProvider.Verify (m => m.RemoveConnection (It.Is<string> (s => s == clientId)));
 			willRepository.Verify (r => r.Delete (It.IsAny<Expression<Func<ConnectionWill, bool>>> ()));
@@ -69,7 +70,8 @@ namespace Tests.Flows
 
 			sessionRepository.Setup(r => r.Get(It.IsAny<Expression<Func<ClientSession, bool>>>())).Returns(session);
 
-			await flow.ExecuteAsync (clientId, disconnect, channel.Object);
+			await flow.ExecuteAsync (clientId, disconnect, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			connectionProvider.Verify (m => m.RemoveConnection (It.Is<string> (s => s == clientId)));
 			willRepository.Verify (r => r.Delete (It.IsAny<Expression<Func<ConnectionWill, bool>>> ()));

--- a/src/Tests/Flows/PingFlowSpec.cs
+++ b/src/Tests/Flows/PingFlowSpec.cs
@@ -23,7 +23,8 @@ namespace Tests.Flows
 
 			var flow = new PingFlow ();
 
-			await flow.ExecuteAsync (clientId, new PingRequest(), channel.Object);
+			await flow.ExecuteAsync (clientId, new PingRequest(), channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			var pingResponse = sentPacket as PingResponse;
 

--- a/src/Tests/Flows/PublishReceiverFlowSpec.cs
+++ b/src/Tests/Flows/PublishReceiverFlowSpec.cs
@@ -95,7 +95,8 @@ namespace Tests.Flows
 
 			channel.Setup (c => c.Receiver).Returns (receiver);
 
-			await flow.ExecuteAsync (clientId, publish, channel.Object);
+			await flow.ExecuteAsync (clientId, publish, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			retainedRepository.Verify (r => r.Create (It.IsAny<RetainedMessage> ()), Times.Never);
 			publishSenderFlow.Verify (s => s.SendPublishAsync (It.Is<string>(x => x == subscribedClientId1), 
@@ -168,7 +169,8 @@ namespace Tests.Flows
 			channel.Setup (c => c.IsConnected).Returns (true);
 			channel.Setup (c => c.Receiver).Returns (receiver);
 
-			await flow.ExecuteAsync (clientId, publish, channel.Object);
+			await flow.ExecuteAsync (clientId, publish, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			retainedRepository.Verify (r => r.Create (It.IsAny<RetainedMessage> ()), Times.Never);
 			publishSenderFlow.Verify (s => s.SendPublishAsync (It.Is<string>(x => x == subscribedClientId), 
@@ -389,7 +391,8 @@ namespace Tests.Flows
 		//		.Returns(Task.Delay(0));
 
 		//	//TODO: Fix this
-		//	await flow.ExecuteAsync (clientId, publish, channel.Object);
+		//	await flow.ExecuteAsync (clientId, publish, channel.Object)
+		//.ConfigureAwait(continueOnCapturedContext: false);
 
 		//	Thread.Sleep (2000);
 
@@ -439,7 +442,8 @@ namespace Tests.Flows
 			var flow = new ServerPublishReceiverFlow (topicEvaluator.Object, connectionProvider.Object, publishSenderFlow.Object,
 				retainedRepository.Object, sessionRepository.Object, packetIdProvider, eventStream, configuration);
 
-			await flow.ExecuteAsync (clientId, publish, channel.Object);
+			await flow.ExecuteAsync (clientId, publish, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			retainedRepository.Verify (r => r.Create (It.Is<RetainedMessage> (m => m.Topic == topic && m.QualityOfService == qos && m.Payload.ToList().SequenceEqual(publish.Payload))));
 			channel.Verify (c => c.SendAsync (It.IsAny<IPacket> ()), Times.Never);
@@ -489,7 +493,8 @@ namespace Tests.Flows
 			var flow = new ServerPublishReceiverFlow (topicEvaluator.Object, connectionProvider.Object, publishSenderFlow.Object,
 				retainedRepository.Object, sessionRepository.Object, packetIdProvider, eventStream, configuration);
 
-			await flow.ExecuteAsync (clientId, publish, channel.Object);
+			await flow.ExecuteAsync (clientId, publish, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			retainedRepository.Verify (r => r.Delete (It.Is<RetainedMessage> (m => m == existingRetainedMessage)));
 			retainedRepository.Verify (r => r.Create (It.Is<RetainedMessage> (m => m.Topic == topic && m.QualityOfService == qos && m.Payload.ToList().SequenceEqual(publish.Payload))));
@@ -555,7 +560,8 @@ namespace Tests.Flows
 			channel.Setup (c => c.IsConnected).Returns (true);
 			channel.Setup (c => c.Receiver).Returns (receiver);
 
-			await flow.ExecuteAsync (clientId, publish, channel.Object);
+			await flow.ExecuteAsync (clientId, publish, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			publishSenderFlow.Verify (s => s.SendPublishAsync (It.Is<string>(x => x == subscribedClientId), 
 				It.Is<Publish> (p => p.Topic == publish.Topic &&
@@ -679,7 +685,8 @@ namespace Tests.Flows
 
 			channel.Setup (c => c.Receiver).Returns (receiver);
 
-			await flow.ExecuteAsync (clientId, publish, channel.Object);
+			await flow.ExecuteAsync (clientId, publish, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Thread.Sleep (2000);
 
@@ -759,7 +766,8 @@ namespace Tests.Flows
 
 			channel.Setup (c => c.Receiver).Returns (receiver);
 
-			await flow.ExecuteAsync (clientId, publish, channel.Object);
+			await flow.ExecuteAsync (clientId, publish, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Thread.Sleep (2000);
 
@@ -801,7 +809,8 @@ namespace Tests.Flows
 
 			channel.Setup (c => c.IsConnected).Returns (true);
 
-			await flow.ExecuteAsync (clientId, publishRelease, channel.Object);
+			await flow.ExecuteAsync (clientId, publishRelease, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			channel.Verify (c => c.SendAsync (It.Is<IPacket> (p => p is PublishComplete && (p as PublishComplete).PacketId == packetId)));
 		}

--- a/src/Tests/Flows/PublishSenderFlowSpec.cs
+++ b/src/Tests/Flows/PublishSenderFlowSpec.cs
@@ -216,7 +216,8 @@ namespace Tests.Flows
 		//	connectionProvider.Setup (m => m.GetConnection (It.Is<string> (s => s == clientId))).Returns (channel.Object);
 
 		//	//TODO: Fix this
-		//	await flow.ExecuteAsync (clientId, publishReceived, channel.Object);
+		//	await flow.ExecuteAsync (clientId, publishReceived, channel.Object)
+		//.ConfigureAwait(continueOnCapturedContext: false);
 
 		//	channel.Verify (c => c.SendAsync (It.Is<IPacket> (p => p is PublishRelease 
 		//		&& (p as PublishRelease).PacketId == packetId)), Times.Once);

--- a/src/Tests/Flows/SubscribeFlowSpec.cs
+++ b/src/Tests/Flows/SubscribeFlowSpec.cs
@@ -58,7 +58,8 @@ namespace Tests.Flows
 			var flow = new ServerSubscribeFlow (topicEvaluator.Object, sessionRepository.Object, 
 				retainedMessageRepository, packetIdProvider, senderFlow, configuration);
 
-			await flow.ExecuteAsync (clientId, subscribe, channel.Object);
+			await flow.ExecuteAsync (clientId, subscribe, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			sessionRepository.Verify (r => r.Update (It.Is<ClientSession> (s => s.ClientId == clientId && s.Subscriptions.Count == 2 
 				&& s.Subscriptions.All(x => x.TopicFilter == fooTopic || x.TopicFilter == barTopic))));
@@ -120,7 +121,8 @@ namespace Tests.Flows
 				retainedMessageRepository, packetIdProvider,
 				senderFlow, configuration);
 
-			await flow.ExecuteAsync (clientId, subscribe, channel.Object);
+			await flow.ExecuteAsync (clientId, subscribe, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			sessionRepository.Verify (r => r.Update (It.Is<ClientSession> (s => s.ClientId == clientId && s.Subscriptions.Count == 1 
 				&& s.Subscriptions.Any(x => x.TopicFilter == fooTopic && x.MaximumQualityOfService == fooQoS))));
@@ -175,7 +177,8 @@ namespace Tests.Flows
 				retainedMessageRepository, packetIdProvider,
 				senderFlow, configuration);
 
-			await flow.ExecuteAsync (clientId, subscribe, channel.Object);
+			await flow.ExecuteAsync (clientId, subscribe, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.NotNull (response);
 
@@ -236,7 +239,8 @@ namespace Tests.Flows
 				sessionRepository.Object, retainedMessageRepository.Object,
 				packetIdProvider, senderFlow.Object, configuration);
 
-			await flow.ExecuteAsync (clientId, subscribe, channel.Object);
+			await flow.ExecuteAsync (clientId, subscribe, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			senderFlow.Verify (f => f.SendPublishAsync (It.Is<string>(s => s == clientId),
 				It.Is<Publish> (p => p.Topic == retainedTopic && 

--- a/src/Tests/Flows/UnsubscribeFlowSpec.cs
+++ b/src/Tests/Flows/UnsubscribeFlowSpec.cs
@@ -51,7 +51,8 @@ namespace Tests.Flows
 
 			var flow = new ServerUnsubscribeFlow (sessionRepository.Object);
 
-			await flow.ExecuteAsync(clientId, unsubscribe, channel.Object);
+			await flow.ExecuteAsync(clientId, unsubscribe, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.NotNull (response);
 			Assert.Equal (0, updatedSession.Subscriptions.Count);
@@ -93,7 +94,8 @@ namespace Tests.Flows
 
 			var flow = new ServerUnsubscribeFlow (sessionRepository.Object);
 
-			await flow.ExecuteAsync(clientId, unsubscribe, channel.Object);
+			await flow.ExecuteAsync(clientId, unsubscribe, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			sessionRepository.Verify (r => r.Delete (It.IsAny<Expression<Func<ClientSession, bool>>> ()), Times.Never);
 			Assert.NotNull (response);

--- a/src/Tests/Formatters/ConnectAckFormatterSpec.cs
+++ b/src/Tests/Formatters/ConnectAckFormatterSpec.cs
@@ -22,7 +22,8 @@ namespace Tests.Formatters
 			var formatter = new ConnectAckFormatter ();
 			var packet = Packet.ReadAllBytes (packetPath);
 
-			var result = await formatter.FormatAsync (packet);
+			var result = await formatter.FormatAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedConnectAck, result);
 		}
@@ -54,7 +55,8 @@ namespace Tests.Formatters
 			var formatter = new ConnectAckFormatter ();
 			var connectAck = Packet.ReadPacket<ConnectAck> (jsonPath);
 
-			var result = await formatter.FormatAsync (connectAck);
+			var result = await formatter.FormatAsync (connectAck)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedPacket, result);
 		}

--- a/src/Tests/Formatters/ConnectFormatterSpec.cs
+++ b/src/Tests/Formatters/ConnectFormatterSpec.cs
@@ -23,7 +23,8 @@ namespace Tests.Formatters
 			var formatter = new ConnectFormatter ();
 			var packet = Packet.ReadAllBytes (packetPath);
 
-			var result = await formatter.FormatAsync (packet);
+			var result = await formatter.FormatAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedConnect, result);
 		}
@@ -76,7 +77,8 @@ namespace Tests.Formatters
 			var formatter = new ConnectFormatter ();
 			var connect = Packet.ReadPacket<Connect> (jsonPath);
 
-			var result = await formatter.FormatAsync (connect);
+			var result = await formatter.FormatAsync (connect)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedPacket, result);
 		}

--- a/src/Tests/Formatters/EmptyPacketFormatterSpec.cs
+++ b/src/Tests/Formatters/EmptyPacketFormatterSpec.cs
@@ -32,7 +32,8 @@ namespace Tests.Formatters
 			var formatter = this.GetFormatter (packetType, type);
 			var packet = Packet.ReadAllBytes (packetPath);
 
-			var result = await formatter.FormatAsync (packet);
+			var result = await formatter.FormatAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.NotNull (result);
 		}
@@ -65,7 +66,8 @@ namespace Tests.Formatters
 			var formatter = this.GetFormatter (packetType, type);
 			var packet = Activator.CreateInstance (type) as IPacket;
 
-			var result = await formatter.FormatAsync (packet);
+			var result = await formatter.FormatAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedPacket, result);
 		}

--- a/src/Tests/Formatters/PublishAckFormatterSpec.cs
+++ b/src/Tests/Formatters/PublishAckFormatterSpec.cs
@@ -22,7 +22,8 @@ namespace Tests.Formatters
 			var formatter = new FlowPacketFormatter<PublishAck>(PacketType.PublishAck, id => new PublishAck(id));
 			var packet = Packet.ReadAllBytes (packetPath);
 
-			var result = await formatter.FormatAsync (packet);
+			var result = await formatter.FormatAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedPublishAck, result);
 		}
@@ -52,7 +53,8 @@ namespace Tests.Formatters
 			var formatter = new FlowPacketFormatter<PublishAck>(PacketType.PublishAck, id => new PublishAck(id));
 			var publishAck = Packet.ReadPacket<PublishAck> (jsonPath);
 
-			var result = await formatter.FormatAsync (publishAck);
+			var result = await formatter.FormatAsync (publishAck)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedPacket, result);
 		}

--- a/src/Tests/Formatters/PublishCompleteFormatterSpec.cs
+++ b/src/Tests/Formatters/PublishCompleteFormatterSpec.cs
@@ -22,7 +22,8 @@ namespace Tests.Formatters
 			var formatter = new FlowPacketFormatter<PublishComplete>(PacketType.PublishComplete, id => new PublishComplete(id));
 			var packet = Packet.ReadAllBytes (packetPath);
 
-			var result = await formatter.FormatAsync (packet);
+			var result = await formatter.FormatAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedPublishComplete, result);
 		}
@@ -52,7 +53,8 @@ namespace Tests.Formatters
 			var formatter = new FlowPacketFormatter<PublishComplete>(PacketType.PublishComplete, id => new PublishComplete(id));
 			var publishComplete = Packet.ReadPacket<PublishComplete> (jsonPath);
 
-			var result = await formatter.FormatAsync (publishComplete);
+			var result = await formatter.FormatAsync (publishComplete)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedPacket, result);
 		}

--- a/src/Tests/Formatters/PublishFormatterSpec.cs
+++ b/src/Tests/Formatters/PublishFormatterSpec.cs
@@ -34,7 +34,8 @@ namespace Tests.Formatters
 			var formatter = new PublishFormatter (topicEvaluator);
 			var packet = Packet.ReadAllBytes (packetPath);
 
-			var result = await formatter.FormatAsync (packet);
+			var result = await formatter.FormatAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedPublish, result);
 		}
@@ -69,7 +70,8 @@ namespace Tests.Formatters
 			var formatter = new PublishFormatter (topicEvaluator);
 			var publish = Packet.ReadPacket<Publish> (jsonPath);
 
-			var result = await formatter.FormatAsync (publish);
+			var result = await formatter.FormatAsync (publish)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedPacket, result);
 		}

--- a/src/Tests/Formatters/PublishReceivedFormatterSpec.cs
+++ b/src/Tests/Formatters/PublishReceivedFormatterSpec.cs
@@ -22,7 +22,8 @@ namespace Tests.Formatters
 			var formatter = new FlowPacketFormatter<PublishReceived>(PacketType.PublishReceived, id => new PublishReceived(id));
 			var packet = Packet.ReadAllBytes (packetPath);
 
-			var result = await formatter.FormatAsync (packet);
+			var result = await formatter.FormatAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedPublishReceived, result);
 		}
@@ -52,7 +53,8 @@ namespace Tests.Formatters
 			var formatter = new FlowPacketFormatter<PublishReceived>(PacketType.PublishReceived, id => new PublishReceived(id));
 			var publishReceived = Packet.ReadPacket<PublishReceived> (jsonPath);
 
-			var result = await formatter.FormatAsync (publishReceived);
+			var result = await formatter.FormatAsync (publishReceived)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedPacket, result);
 		}

--- a/src/Tests/Formatters/PublishReleaseFormatterSpec.cs
+++ b/src/Tests/Formatters/PublishReleaseFormatterSpec.cs
@@ -22,7 +22,8 @@ namespace Tests.Formatters
 			var formatter = new FlowPacketFormatter<PublishRelease>(PacketType.PublishRelease, id => new PublishRelease(id));
 			var packet = Packet.ReadAllBytes (packetPath);
 
-			var result = await formatter.FormatAsync (packet);
+			var result = await formatter.FormatAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedPublishRelease, result);
 		}
@@ -52,7 +53,8 @@ namespace Tests.Formatters
 			var formatter = new FlowPacketFormatter<PublishRelease>(PacketType.PublishRelease, id => new PublishRelease(id));
 			var publishRelease = Packet.ReadPacket<PublishRelease> (jsonPath);
 
-			var result = await formatter.FormatAsync (publishRelease);
+			var result = await formatter.FormatAsync (publishRelease)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedPacket, result);
 		}

--- a/src/Tests/Formatters/SubscribeAckFormatterSpec.cs
+++ b/src/Tests/Formatters/SubscribeAckFormatterSpec.cs
@@ -23,7 +23,8 @@ namespace Tests.Formatters
 			var formatter = new SubscribeAckFormatter ();
 			var packet = Packet.ReadAllBytes (packetPath);
 
-			var result = await formatter.FormatAsync (packet);
+			var result = await formatter.FormatAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedSubscribeAck, result);
 		}
@@ -69,7 +70,8 @@ namespace Tests.Formatters
 			var formatter = new SubscribeAckFormatter ();
 			var subscribeAck = Packet.ReadPacket<SubscribeAck> (jsonPath);
 
-			var result = await formatter.FormatAsync (subscribeAck);
+			var result = await formatter.FormatAsync (subscribeAck)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedPacket, result);
 		}

--- a/src/Tests/Formatters/SubscribeFormatterSpec.cs
+++ b/src/Tests/Formatters/SubscribeFormatterSpec.cs
@@ -25,7 +25,8 @@ namespace Tests.Formatters
 			var formatter = new SubscribeFormatter (topicEvaluator);
 			var packet = Packet.ReadAllBytes (packetPath);
 
-			var result = await formatter.FormatAsync (packet);
+			var result = await formatter.FormatAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedSubscribe, result);
 		}
@@ -75,7 +76,8 @@ namespace Tests.Formatters
 			var formatter = new SubscribeFormatter (topicEvaluator);
 			var subscribe = Packet.ReadPacket<Subscribe> (jsonPath);
 
-			var result = await formatter.FormatAsync (subscribe);
+			var result = await formatter.FormatAsync (subscribe)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedPacket, result);
 		}

--- a/src/Tests/Formatters/UnsubscribeAckFormatterSpec.cs
+++ b/src/Tests/Formatters/UnsubscribeAckFormatterSpec.cs
@@ -22,7 +22,8 @@ namespace Tests.Formatters
 			var formatter = new FlowPacketFormatter<UnsubscribeAck>(PacketType.UnsubscribeAck, id => new UnsubscribeAck(id));
 			var packet = Packet.ReadAllBytes (packetPath);
 
-			var result = await formatter.FormatAsync (packet);
+			var result = await formatter.FormatAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedUnsubscribeAck, result);
 		}
@@ -52,7 +53,8 @@ namespace Tests.Formatters
 			var formatter = new FlowPacketFormatter<UnsubscribeAck>(PacketType.UnsubscribeAck, id => new UnsubscribeAck(id));
 			var unsubscribeAck = Packet.ReadPacket<UnsubscribeAck> (jsonPath);
 
-			var result = await formatter.FormatAsync (unsubscribeAck);
+			var result = await formatter.FormatAsync (unsubscribeAck)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedPacket, result);
 		}

--- a/src/Tests/Formatters/UnsubscribeFormatterSpec.cs
+++ b/src/Tests/Formatters/UnsubscribeFormatterSpec.cs
@@ -23,7 +23,8 @@ namespace Tests.Formatters
 			var formatter = new UnsubscribeFormatter ();
 			var packet = Packet.ReadAllBytes (packetPath);
 
-			var result = await formatter.FormatAsync (packet);
+			var result = await formatter.FormatAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedUnsubscribe, result);
 		}
@@ -68,7 +69,8 @@ namespace Tests.Formatters
 			var formatter = new UnsubscribeFormatter ();
 			var unsubscribe = Packet.ReadPacket<Unsubscribe> (jsonPath);
 
-			var result = await formatter.FormatAsync (unsubscribe);
+			var result = await formatter.FormatAsync (unsubscribe)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (expectedPacket, result);
 		}

--- a/src/Tests/PacketChannelSpec.cs
+++ b/src/Tests/PacketChannelSpec.cs
@@ -160,7 +160,8 @@ namespace Tests
 
 			var channel = new PacketChannel (innerChannel.Object, manager.Object, configuration);
 
-			await channel.SendAsync (packet);
+			await channel.SendAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			innerChannel.Verify (x => x.SendAsync (It.Is<byte[]> (b => b.ToList ().SequenceEqual (bytes))));
 			manager.Verify (x => x.GetBytesAsync (It.Is<IPacket> (p => Convert.ChangeType(p, packetType) == packet)));
@@ -194,7 +195,8 @@ namespace Tests
 
 			var channel = new PacketChannel (innerChannel.Object, manager.Object, configuration);
 
-			await channel.SendAsync (packet);
+			await channel.SendAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			innerChannel.Verify (x => x.SendAsync (It.Is<byte[]> (b => b.ToList ().SequenceEqual (bytes))));
 			manager.Verify (x => x.GetBytesAsync (It.Is<IPacket> (p => Convert.ChangeType(p, packetType) == packet)));

--- a/src/Tests/PacketManagerSpec.cs
+++ b/src/Tests/PacketManagerSpec.cs
@@ -48,7 +48,8 @@ namespace Tests
 				.Returns (Task.FromResult<IPacket>((IPacket)packet));
 
 			var packetManager = new PacketManager (formatter.Object);
-			var result =  await packetManager.GetPacketAsync (bytes);
+			var result =  await packetManager.GetPacketAsync (bytes)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (packet, result);
 		}
@@ -88,7 +89,8 @@ namespace Tests
 				.Returns (Task.FromResult(bytes));
 
 			var packetManager = new PacketManager (formatter.Object);
-			var result = await packetManager.GetBytesAsync (packet);
+			var result = await packetManager.GetBytesAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (bytes, result);
 		}
@@ -113,7 +115,8 @@ namespace Tests
 				.Returns (Task.FromResult(bytes));
 
 			var packetManager = new PacketManager (formatter.Object);
-			var result = await packetManager.GetBytesAsync (packet);
+			var result = await packetManager.GetBytesAsync (packet)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			Assert.Equal (bytes, result);
 		}


### PR DESCRIPTION
- Using ConfigureAwait in all the awaits is a good practice when developing libraries or frameworks, to reduce possible deadlocks when used on a mix of blocking code and async code.
- When using synchronous blocking code to run async code, this could end up in deadlocks caused by the nature of async/await methods. Synchronous blocking code implies i.e. using Task.Wait() or Task.Result to run async methods, which will block the current thread of the current synchronization context until the task completes. When the await inside the async methods completes, it will try to resume on the previously captured synchronization context. Given that the context is already retained by the blocking code, it will cause a deadlock because both parts are waiting to each other to complete. This pattern is very common and using ConfigureAwait(false), the continuations after await will not run on the captured synchronization context, which could save deadlocks considerably.
- Also, Context-Free code could have better performance
