### PR TITLE
Ensured disposal of custom Task Schedulers to avoid living threads

### DIFF
--- a/src/Client/ApplicationMessage.cs
+++ b/src/Client/ApplicationMessage.cs
@@ -9,12 +9,12 @@
 
 		public ApplicationMessage (string topic, byte[] payload)
 		{
-			this.Topic = topic;
-			this.Payload = payload;
+			Topic = topic;
+			Payload = payload;
 		}
 
-        public string Topic { get; set; }
+		public string Topic { get; set; }
 
-        public byte[] Payload { get; set; }
+		public byte[] Payload { get; set; }
 	}
 }

--- a/src/Client/ClientCredentials.cs
+++ b/src/Client/ClientCredentials.cs
@@ -4,14 +4,14 @@
 	{
 		public ClientCredentials (string clientId)
 		{
-			this.ClientId = clientId;
+			ClientId = clientId;
 		}
 
 		public ClientCredentials (string clientId, string userName, string password)
 		{
-			this.ClientId = clientId;
-			this.UserName = userName;
-			this.Password = password;
+			ClientId = clientId;
+			UserName = userName;
+			Password = password;
 		}
 
 		public string ClientId { get; private set; }

--- a/src/Client/ClientInitializer.cs
+++ b/src/Client/ClientInitializer.cs
@@ -25,7 +25,7 @@ namespace System.Net.Mqtt.Client
 				//TODO: The ChannelFactory injection must be handled better. I would not assume Tcp by default. 
 				//Instead I would delegate the implementation to a different NuGet or assembly.
 				//Maybe having one assembly per factory implementation (like TcpChannelFactory, WebSocketChannelFactory, TLSChannelFactory, etc)
-				var channelFactory = new PacketChannelFactory(this.innerChannelFactory ?? new TcpChannelFactory (this.hostAddress, configuration), 
+				var channelFactory = new PacketChannelFactory(innerChannelFactory ?? new TcpChannelFactory (hostAddress, configuration),
 					topicEvaluator, configuration);
 				var packetIdProvider = new PacketIdProvider ();
 				var repositoryProvider = new InMemoryRepositoryProvider();

--- a/src/Client/Flows/ClientConnectFlow.cs
+++ b/src/Client/Flows/ClientConnectFlow.cs
@@ -10,7 +10,7 @@ namespace System.Net.Mqtt.Flows
 		readonly IRepository<ClientSession> sessionRepository;
 		readonly IPublishSenderFlow senderFlow;
 
-		public ClientConnectFlow (IRepository<ClientSession> sessionRepository, 
+		public ClientConnectFlow (IRepository<ClientSession> sessionRepository,
 			IPublishSenderFlow senderFlow)
 		{
 			this.sessionRepository = sessionRepository;
@@ -29,43 +29,43 @@ namespace System.Net.Mqtt.Flows
 				return;
 			}
 
-			var session = this.sessionRepository.Get (s => s.ClientId == clientId);
+			var session = sessionRepository.Get (s => s.ClientId == clientId);
 
 			if (session == null) {
 				throw new MqttException (string.Format (Properties.Resources.SessionRepository_ClientSessionNotFound, clientId));
 			}
 
-			await this.SendPendingMessagesAsync (session, channel)
-				.ConfigureAwait(continueOnCapturedContext: false);
-			await this.SendPendingAcknowledgementsAsync (session, channel)
-				.ConfigureAwait(continueOnCapturedContext: false);
+			await SendPendingMessagesAsync (session, channel)
+				.ConfigureAwait (continueOnCapturedContext: false);
+			await SendPendingAcknowledgementsAsync (session, channel)
+				.ConfigureAwait (continueOnCapturedContext: false);
 		}
 
-		private async Task SendPendingMessagesAsync(ClientSession session, IChannel<IPacket> channel)
+		async Task SendPendingMessagesAsync (ClientSession session, IChannel<IPacket> channel)
 		{
-			foreach (var pendingMessage in session.GetPendingMessages()) {
-				var publish = new Publish(pendingMessage.Topic, pendingMessage.QualityOfService, 
+			foreach (var pendingMessage in session.GetPendingMessages ()) {
+				var publish = new Publish(pendingMessage.Topic, pendingMessage.QualityOfService,
 					pendingMessage.Retain, pendingMessage.Duplicated, pendingMessage.PacketId);
 
-				await this.senderFlow
+				await senderFlow
 					.SendPublishAsync (session.ClientId, publish, channel, PendingMessageStatus.PendingToAcknowledge)
-					.ConfigureAwait(continueOnCapturedContext: false);
+					.ConfigureAwait (continueOnCapturedContext: false);
 			}
 		}
 
-		private async Task SendPendingAcknowledgementsAsync(ClientSession session, IChannel<IPacket> channel)
+		async Task SendPendingAcknowledgementsAsync (ClientSession session, IChannel<IPacket> channel)
 		{
-			foreach (var pendingAcknowledgement in session.GetPendingAcknowledgements()) {
+			foreach (var pendingAcknowledgement in session.GetPendingAcknowledgements ()) {
 				var ack = default(IFlowPacket);
 
 				if (pendingAcknowledgement.Type == PacketType.PublishReceived) {
 					ack = new PublishReceived (pendingAcknowledgement.PacketId);
-				} else if(pendingAcknowledgement.Type == PacketType.PublishRelease) {
+				} else if (pendingAcknowledgement.Type == PacketType.PublishRelease) {
 					ack = new PublishRelease (pendingAcknowledgement.PacketId);
 				}
 
-				await this.senderFlow.SendAckAsync (session.ClientId, ack, channel)
-					.ConfigureAwait(continueOnCapturedContext: false);
+				await senderFlow.SendAckAsync (session.ClientId, ack, channel)
+					.ConfigureAwait (continueOnCapturedContext: false);
 			}
 		}
 	}

--- a/src/Client/Flows/ClientProtocolFlowProvider.cs
+++ b/src/Client/Flows/ClientProtocolFlowProvider.cs
@@ -7,7 +7,7 @@ namespace System.Net.Mqtt.Flows
 	internal class ClientProtocolFlowProvider : ProtocolFlowProvider
 	{
 		public ClientProtocolFlowProvider (ITopicEvaluator topicEvaluator, IRepositoryProvider repositoryProvider, ProtocolConfiguration configuration)
-			: base(topicEvaluator, repositoryProvider, configuration)
+			: base (topicEvaluator, repositoryProvider, configuration)
 		{
 		}
 
@@ -21,7 +21,7 @@ namespace System.Net.Mqtt.Flows
 
 			flows.Add (ProtocolFlowType.Connect, new ClientConnectFlow (sessionRepository, senderFlow));
 			flows.Add (ProtocolFlowType.PublishSender, senderFlow);
-			flows.Add (ProtocolFlowType.PublishReceiver, new PublishReceiverFlow (topicEvaluator, 
+			flows.Add (ProtocolFlowType.PublishReceiver, new PublishReceiverFlow (topicEvaluator,
 				retainedRepository, sessionRepository, configuration));
 			flows.Add (ProtocolFlowType.Subscribe, new ClientSubscribeFlow ());
 			flows.Add (ProtocolFlowType.Unsubscribe, new ClientUnsubscribeFlow ());

--- a/src/Client/Flows/ClientSubscribeFlow.cs
+++ b/src/Client/Flows/ClientSubscribeFlow.cs
@@ -7,7 +7,7 @@ namespace System.Net.Mqtt.Flows
 	{
 		public Task ExecuteAsync (string clientId, IPacket input, IChannel<IPacket> channel)
 		{
-			return Task.Delay(0);
+			return Task.Delay (0);
 		}
 	}
 }

--- a/src/Client/Flows/ClientUnsubscribeFlow.cs
+++ b/src/Client/Flows/ClientUnsubscribeFlow.cs
@@ -7,7 +7,7 @@ namespace System.Net.Mqtt.Flows
 	{
 		public Task ExecuteAsync (string clientId, IPacket input, IChannel<IPacket> channel)
 		{
-			return Task.Delay(0);
+			return Task.Delay (0);
 		}
 	}
 }

--- a/src/Core/ByteExtensions.cs
+++ b/src/Core/ByteExtensions.cs
@@ -5,47 +5,47 @@ namespace System.Net.Mqtt
 {
 	public static class ByteExtensions
 	{
-		public static bool IsSet(this byte @byte, int bit)
-        {
-            if (bit > 7)
-                throw new ArgumentOutOfRangeException("bit", Properties.Resources.ByteExtensions_InvalidBitPosition);
+		public static bool IsSet (this byte @byte, int bit)
+		{
+			if (bit > 7)
+				throw new ArgumentOutOfRangeException ("bit", Properties.Resources.ByteExtensions_InvalidBitPosition);
 
-            return (@byte & (1 << bit)) != 0;
-        }
+			return (@byte & (1 << bit)) != 0;
+		}
 
-        public static byte Set(this byte @byte, int bit)
-        {
-            if (bit > 7)
-                throw new ArgumentOutOfRangeException("bit", Properties.Resources.ByteExtensions_InvalidBitPosition);
+		public static byte Set (this byte @byte, int bit)
+		{
+			if (bit > 7)
+				throw new ArgumentOutOfRangeException ("bit", Properties.Resources.ByteExtensions_InvalidBitPosition);
 
-            return Convert.ToByte(@byte | (1 << bit));
-        }
+			return Convert.ToByte (@byte | (1 << bit));
+		}
 
-        public static byte Unset(this byte @byte, int bit)
-        {
-            if (bit > 7)
-                throw new ArgumentOutOfRangeException("bit", Properties.Resources.ByteExtensions_InvalidBitPosition);
+		public static byte Unset (this byte @byte, int bit)
+		{
+			if (bit > 7)
+				throw new ArgumentOutOfRangeException ("bit", Properties.Resources.ByteExtensions_InvalidBitPosition);
 
-            return Convert.ToByte(@byte & ~(1 << bit));
-        }
+			return Convert.ToByte (@byte & ~(1 << bit));
+		}
 
-        public static byte Toggle(this byte @byte, int bit)
-        {
-            if (bit > 7)
-                throw new ArgumentOutOfRangeException("bit", Properties.Resources.ByteExtensions_InvalidBitPosition);
+		public static byte Toggle (this byte @byte, int bit)
+		{
+			if (bit > 7)
+				throw new ArgumentOutOfRangeException ("bit", Properties.Resources.ByteExtensions_InvalidBitPosition);
 
-            return Convert.ToByte(@byte ^ (1 << bit));
-        }
+			return Convert.ToByte (@byte ^ (1 << bit));
+		}
 
-        public static byte Bits(this byte @byte, int count)
-        {
-            return Convert.ToByte(@byte >> 8 - count);
-        }
+		public static byte Bits (this byte @byte, int count)
+		{
+			return Convert.ToByte (@byte >> 8 - count);
+		}
 
-        public static byte Bits(this byte @byte, int index, int count)
-        {
+		public static byte Bits (this byte @byte, int index, int count)
+		{
 			if (index < 1 || index > 8)
-				throw new ArgumentOutOfRangeException("index", Properties.Resources.ByteExtensions_InvalidByteIndex);
+				throw new ArgumentOutOfRangeException ("index", Properties.Resources.ByteExtensions_InvalidByteIndex);
 
 			if (index > 1) {
 				var i = 1;
@@ -56,35 +56,35 @@ namespace System.Net.Mqtt
 				} while (i < index);
 			}
 
-            var to = Convert.ToByte(@byte << index - 1);
-            var from = Convert.ToByte(to >> 8 - count);
+			var to = Convert.ToByte(@byte << index - 1);
+			var from = Convert.ToByte(to >> 8 - count);
 
-            return from;
-        }
-
-		public static byte Byte(this byte[] bytes, int index)
-		{
-			return bytes.Skip (index).Take (1).FirstOrDefault();
+			return from;
 		}
 
-		public static byte[] Bytes(this byte[] bytes, int fromIndex)
+		public static byte Byte (this byte[] bytes, int index)
+		{
+			return bytes.Skip (index).Take (1).FirstOrDefault ();
+		}
+
+		public static byte[] Bytes (this byte[] bytes, int fromIndex)
 		{
 			return bytes.Skip (fromIndex).ToArray ();
 		}
 
-		public static byte[] Bytes(this byte[] bytes, int fromIndex, int count)
+		public static byte[] Bytes (this byte[] bytes, int fromIndex, int count)
 		{
-			return bytes.Skip (fromIndex).Take (count).ToArray();
+			return bytes.Skip (fromIndex).Take (count).ToArray ();
 		}
 
-		public static string GetString(this byte[] bytes, int index)
+		public static string GetString (this byte[] bytes, int index)
 		{
 			var length = bytes.GetStringLenght (index);
-			
+
 			return length == 0 ? string.Empty : Encoding.UTF8.GetString (bytes, index + Protocol.StringPrefixLength, length);
 		}
 
-		public static string GetString(this byte[] bytes, int index, out int nextIndex)
+		public static string GetString (this byte[] bytes, int index, out int nextIndex)
 		{
 			var length = bytes.GetStringLenght (index);
 
@@ -102,7 +102,7 @@ namespace System.Net.Mqtt
 			return BitConverter.ToUInt16 (bytes, 0);
 		}
 
-		private static ushort GetStringLenght(this byte[] bytes, int index)
+		static ushort GetStringLenght (this byte[] bytes, int index)
 		{
 			return bytes.Bytes (index, 2).ToUInt16 ();
 		}

--- a/src/Core/Exceptions/MqttConnectionException.cs
+++ b/src/Core/Exceptions/MqttConnectionException.cs
@@ -8,17 +8,17 @@ namespace System.Net.Mqtt.Exceptions
 	{
 		public MqttConnectionException (ConnectionStatus status)
 		{
-			this.ReturnCode = status;
+			ReturnCode = status;
 		}
 
-		public MqttConnectionException (ConnectionStatus status, string message) : base(message)
+		public MqttConnectionException (ConnectionStatus status, string message) : base (message)
 		{
-			this.ReturnCode = status;
+			ReturnCode = status;
 		}
 
-		public MqttConnectionException (ConnectionStatus status, string message, Exception innerException) : base(message, innerException)
+		public MqttConnectionException (ConnectionStatus status, string message, Exception innerException) : base (message, innerException)
 		{
-			this.ReturnCode = status;
+			ReturnCode = status;
 		}
 
 		protected MqttConnectionException (SerializationInfo info, StreamingContext context)

--- a/src/Core/Exceptions/MqttException.cs
+++ b/src/Core/Exceptions/MqttException.cs
@@ -9,11 +9,11 @@ namespace System.Net.Mqtt.Exceptions
 		{
 		}
 
-		public MqttException (string message) : base(message)
+		public MqttException (string message) : base (message)
 		{
 		}
 
-		public MqttException (string message, Exception innerException) : base(message, innerException)
+		public MqttException (string message, Exception innerException) : base (message, innerException)
 		{
 		}
 

--- a/src/Core/Exceptions/MqttViolationException.cs
+++ b/src/Core/Exceptions/MqttViolationException.cs
@@ -9,11 +9,11 @@ namespace System.Net.Mqtt.Exceptions
 		{
 		}
 
-		public MqttViolationException (string message) : base(message)
+		public MqttViolationException (string message) : base (message)
 		{
 		}
 
-		public MqttViolationException (string message, Exception innerException) : base(message, innerException)
+		public MqttViolationException (string message, Exception innerException) : base (message, innerException)
 		{
 		}
 

--- a/src/Core/Exceptions/RepositoryException.cs
+++ b/src/Core/Exceptions/RepositoryException.cs
@@ -9,11 +9,11 @@ namespace System.Net.Mqtt.Exceptions
 		{
 		}
 
-		public RepositoryException (string message) : base(message)
+		public RepositoryException (string message) : base (message)
 		{
 		}
 
-		public RepositoryException (string message, Exception innerException) : base(message, innerException)
+		public RepositoryException (string message, Exception innerException) : base (message, innerException)
 		{
 		}
 

--- a/src/Core/Extensions.cs
+++ b/src/Core/Extensions.cs
@@ -5,7 +5,7 @@ namespace System.Net.Mqtt
 {
 	internal static class Extensions
 	{
-		internal static ProtocolFlowType ToFlowType(this PacketType packetType)
+		internal static ProtocolFlowType ToFlowType (this PacketType packetType)
 		{
 			var flowType = default (ProtocolFlowType);
 
@@ -43,14 +43,14 @@ namespace System.Net.Mqtt
 			return flowType;
 		}
 
-		internal static QualityOfService GetSupportedQos(this ProtocolConfiguration configuration, QualityOfService requestedQos)
+		internal static QualityOfService GetSupportedQos (this ProtocolConfiguration configuration, QualityOfService requestedQos)
 		{
 			return requestedQos > configuration.MaximumQualityOfService ?
-				configuration.MaximumQualityOfService : 
+				configuration.MaximumQualityOfService :
 				requestedQos;
 		}
 
-		internal static SubscribeReturnCode ToReturnCode(this QualityOfService qos)
+		internal static SubscribeReturnCode ToReturnCode (this QualityOfService qos)
 		{
 			var returnCode = default (SubscribeReturnCode);
 

--- a/src/Core/Flows/PingFlow.cs
+++ b/src/Core/Flows/PingFlow.cs
@@ -11,8 +11,8 @@ namespace System.Net.Mqtt.Flows
 				return;
 			}
 
-			await channel.SendAsync(new PingResponse())
-				.ConfigureAwait(continueOnCapturedContext: false);
+			await channel.SendAsync (new PingResponse ())
+				.ConfigureAwait (continueOnCapturedContext: false);
 		}
 	}
 }

--- a/src/Core/Flows/ProtocolFlowProvider.cs
+++ b/src/Core/Flows/ProtocolFlowProvider.cs
@@ -14,8 +14,8 @@ namespace System.Net.Mqtt.Flows
 
 		IDictionary<ProtocolFlowType, IProtocolFlow> flows;
 
-		protected ProtocolFlowProvider (ITopicEvaluator topicEvaluator, 
-			IRepositoryProvider repositoryProvider, 
+		protected ProtocolFlowProvider (ITopicEvaluator topicEvaluator,
+			IRepositoryProvider repositoryProvider,
 			ProtocolConfiguration configuration)
 		{
 			this.topicEvaluator = topicEvaluator;
@@ -30,28 +30,28 @@ namespace System.Net.Mqtt.Flows
 		/// <exception cref="MqttException">ProtocolException</exception>
 		public IProtocolFlow GetFlow (PacketType packetType)
 		{
-			if (!this.IsValidPacketType (packetType)) {
+			if (!IsValidPacketType (packetType)) {
 				var error = string.Format (Properties.Resources.ProtocolFlowProvider_InvalidPacketType, packetType);
-				
+
 				throw new MqttException (error);
 			}
 
 			var flow = default (IProtocolFlow);
 			var flowType = packetType.ToFlowType();
 
-			if (!this.GetFlows().TryGetValue (flowType, out flow)) {
+			if (!GetFlows ().TryGetValue (flowType, out flow)) {
 				var error = string.Format (Properties.Resources.ProtocolFlowProvider_UnknownPacketType, packetType);
-				
+
 				throw new MqttException (error);
 			}
 
 			return flow;
 		}
 
-		public T GetFlow<T> () 
+		public T GetFlow<T> ()
 			where T : class, IProtocolFlow
 		{
-			var pair = this.GetFlows().FirstOrDefault (f => f.Value is T);
+			var pair = GetFlows().FirstOrDefault (f => f.Value is T);
 
 			if (pair.Equals (default (KeyValuePair<ProtocolFlowType, IProtocolFlow>))) {
 				return default (T);
@@ -60,13 +60,13 @@ namespace System.Net.Mqtt.Flows
 			return pair.Value as T;
 		}
 
-		private IDictionary<ProtocolFlowType, IProtocolFlow> GetFlows()
+		IDictionary<ProtocolFlowType, IProtocolFlow> GetFlows ()
 		{
-			if (this.flows == default (IDictionary<ProtocolFlowType, IProtocolFlow>)) {
-				this.flows = this.InitializeFlows ();
+			if (flows == default (IDictionary<ProtocolFlowType, IProtocolFlow>)) {
+				flows = InitializeFlows ();
 			}
 
-			return this.flows;
+			return flows;
 		}
 	}
 }

--- a/src/Core/Flows/PublishReceiverFlow.cs
+++ b/src/Core/Flows/PublishReceiverFlow.cs
@@ -12,10 +12,10 @@ namespace System.Net.Mqtt.Flows
 		protected readonly IRepository<RetainedMessage> retainedRepository;
 
 		public PublishReceiverFlow (ITopicEvaluator topicEvaluator,
-			IRepository<RetainedMessage> retainedRepository, 
+			IRepository<RetainedMessage> retainedRepository,
 			IRepository<ClientSession> sessionRepository,
 			ProtocolConfiguration configuration)
-			: base(sessionRepository, configuration)
+			: base (sessionRepository, configuration)
 		{
 			this.topicEvaluator = topicEvaluator;
 			this.retainedRepository = retainedRepository;
@@ -26,22 +26,22 @@ namespace System.Net.Mqtt.Flows
 			if (input.Type == PacketType.Publish) {
 				var publish = input as Publish;
 
-				await this.HandlePublishAsync (clientId, publish, channel)
-					.ConfigureAwait(continueOnCapturedContext: false);
+				await HandlePublishAsync (clientId, publish, channel)
+					.ConfigureAwait (continueOnCapturedContext: false);
 			} else if (input.Type == PacketType.PublishRelease) {
 				var publishRelease = input as PublishRelease;
 
-				await this.HandlePublishReleaseAsync (clientId, publishRelease, channel)
-					.ConfigureAwait(continueOnCapturedContext: false);
+				await HandlePublishReleaseAsync (clientId, publishRelease, channel)
+					.ConfigureAwait (continueOnCapturedContext: false);
 			}
 		}
 
-		protected virtual Task ProcessPublishAsync(Publish publish, string clientId)
+		protected virtual Task ProcessPublishAsync (Publish publish, string clientId)
 		{
 			return Task.Delay (0);
 		}
 
-		private async Task HandlePublishAsync(string clientId, Publish publish, IChannel<IPacket> channel)
+		async Task HandlePublishAsync (string clientId, Publish publish, IChannel<IPacket> channel)
 		{
 			if (publish.QualityOfService != QualityOfService.AtMostOnce && !publish.PacketId.HasValue) {
 				throw new MqttException (Properties.Resources.PublishReceiverFlow_PacketIdRequired);
@@ -50,45 +50,45 @@ namespace System.Net.Mqtt.Flows
 			if (publish.QualityOfService == QualityOfService.AtMostOnce && publish.PacketId.HasValue) {
 				throw new MqttException (Properties.Resources.PublishReceiverFlow_PacketIdNotAllowed);
 			}
-			
+
 			var qos = configuration.GetSupportedQos(publish.QualityOfService);
-			var session = this.sessionRepository.Get (s => s.ClientId == clientId);
+			var session = sessionRepository.Get (s => s.ClientId == clientId);
 
 			if (session == null) {
-				throw new MqttException (string.Format(Properties.Resources.SessionRepository_ClientSessionNotFound, clientId));
+				throw new MqttException (string.Format (Properties.Resources.SessionRepository_ClientSessionNotFound, clientId));
 			}
 
-			if(qos == QualityOfService.ExactlyOnce && session.GetPendingAcknowledgements().Any(ack => ack.Type == PacketType.PublishReceived && ack.PacketId == publish.PacketId.Value)) {
-				await this.SendQosAck (clientId, qos, publish, channel)
-					.ConfigureAwait(continueOnCapturedContext: false);
+			if (qos == QualityOfService.ExactlyOnce && session.GetPendingAcknowledgements ().Any (ack => ack.Type == PacketType.PublishReceived && ack.PacketId == publish.PacketId.Value)) {
+				await SendQosAck (clientId, qos, publish, channel)
+					.ConfigureAwait (continueOnCapturedContext: false);
 
 				return;
 			}
 
-			await this.SendQosAck (clientId, qos, publish, channel)
-				.ConfigureAwait(continueOnCapturedContext: false);
-			await this.ProcessPublishAsync(publish, clientId)
-				.ConfigureAwait(continueOnCapturedContext: false);
+			await SendQosAck (clientId, qos, publish, channel)
+				.ConfigureAwait (continueOnCapturedContext: false);
+			await ProcessPublishAsync (publish, clientId)
+				.ConfigureAwait (continueOnCapturedContext: false);
 		}
 
-		private async Task HandlePublishReleaseAsync(string clientId, PublishRelease publishRelease, IChannel<IPacket> channel)
+		async Task HandlePublishReleaseAsync (string clientId, PublishRelease publishRelease, IChannel<IPacket> channel)
 		{
-			this.RemovePendingAcknowledgement (clientId, publishRelease.PacketId, PacketType.PublishReceived);
+			RemovePendingAcknowledgement (clientId, publishRelease.PacketId, PacketType.PublishReceived);
 
-			await this.SendAckAsync (clientId, new PublishComplete (publishRelease.PacketId), channel)
-				.ConfigureAwait(continueOnCapturedContext: false);
+			await SendAckAsync (clientId, new PublishComplete (publishRelease.PacketId), channel)
+				.ConfigureAwait (continueOnCapturedContext: false);
 		}
 
-		private async Task SendQosAck(string clientId, QualityOfService qos, Publish publish, IChannel<IPacket> channel)
+		async Task SendQosAck (string clientId, QualityOfService qos, Publish publish, IChannel<IPacket> channel)
 		{
 			if (qos == QualityOfService.AtMostOnce) {
 				return;
 			} else if (qos == QualityOfService.AtLeastOnce) {
-				await this.SendAckAsync (clientId, new PublishAck (publish.PacketId.Value), channel)
-					.ConfigureAwait(continueOnCapturedContext: false);
+				await SendAckAsync (clientId, new PublishAck (publish.PacketId.Value), channel)
+					.ConfigureAwait (continueOnCapturedContext: false);
 			} else {
-				await this.SendAckAsync (clientId, new PublishReceived (publish.PacketId.Value), channel)
-					.ConfigureAwait(continueOnCapturedContext: false);
+				await SendAckAsync (clientId, new PublishReceived (publish.PacketId.Value), channel)
+					.ConfigureAwait (continueOnCapturedContext: false);
 			}
 		}
 	}

--- a/src/Core/Flows/PublishSenderFlow.cs
+++ b/src/Core/Flows/PublishSenderFlow.cs
@@ -12,22 +12,22 @@ namespace System.Net.Mqtt.Flows
 {
 	internal class PublishSenderFlow : PublishFlow, IPublishSenderFlow
 	{
-		private static readonly ITracer tracer = Tracer.Get<PublishSenderFlow> ();
+		static readonly ITracer tracer = Tracer.Get<PublishSenderFlow> ();
 
 		IDictionary<PacketType, Func<string, ushort, IFlowPacket>> senderRules;
 
 		public PublishSenderFlow (IRepository<ClientSession> sessionRepository,
 			ProtocolConfiguration configuration)
-			: base(sessionRepository, configuration)
+			: base (sessionRepository, configuration)
 		{
-			this.DefineSenderRules ();
+			DefineSenderRules ();
 		}
 
 		public override async Task ExecuteAsync (string clientId, IPacket input, IChannel<IPacket> channel)
 		{
 			var senderRule = default (Func<string, ushort, IFlowPacket>);
 
-			if (!this.senderRules.TryGetValue (input.Type, out senderRule)) {
+			if (!senderRules.TryGetValue (input.Type, out senderRule)) {
 				return;
 			}
 
@@ -39,33 +39,33 @@ namespace System.Net.Mqtt.Flows
 
 			var ackPacket = senderRule (clientId, flowPacket.PacketId);
 
-			if (ackPacket != default(IFlowPacket)) {
-				await this.SendAckAsync (clientId, ackPacket, channel)
-					.ConfigureAwait(continueOnCapturedContext: false);
+			if (ackPacket != default (IFlowPacket)) {
+				await SendAckAsync (clientId, ackPacket, channel)
+					.ConfigureAwait (continueOnCapturedContext: false);
 			}
 		}
 
 		public async Task SendPublishAsync (string clientId, Publish message, IChannel<IPacket> channel, PendingMessageStatus status = PendingMessageStatus.PendingToSend)
 		{
 			if (channel == null || !channel.IsConnected) {
-				this.SaveMessage (message, clientId, PendingMessageStatus.PendingToSend);
+				SaveMessage (message, clientId, PendingMessageStatus.PendingToSend);
 				return;
 			}
 
-			var qos = this.configuration.GetSupportedQos(message.QualityOfService);
+			var qos = configuration.GetSupportedQos(message.QualityOfService);
 
 			if (qos != QualityOfService.AtMostOnce && status == PendingMessageStatus.PendingToSend) {
-				this.SaveMessage (message, clientId, PendingMessageStatus.PendingToAcknowledge);
+				SaveMessage (message, clientId, PendingMessageStatus.PendingToAcknowledge);
 			}
 
 			await channel.SendAsync (message)
-				.ConfigureAwait(continueOnCapturedContext: false);
+				.ConfigureAwait (continueOnCapturedContext: false);
 
-			if(qos == QualityOfService.AtLeastOnce) {
-				await this.MonitorAckAsync<PublishAck> (message, clientId, channel)
-					.ConfigureAwait(continueOnCapturedContext: false);
+			if (qos == QualityOfService.AtLeastOnce) {
+				await MonitorAckAsync<PublishAck> (message, clientId, channel)
+					.ConfigureAwait (continueOnCapturedContext: false);
 			} else if (qos == QualityOfService.ExactlyOnce) {
-				await this.MonitorAckAsync<PublishReceived> (message, clientId, channel).ConfigureAwait(continueOnCapturedContext: false);
+				await MonitorAckAsync<PublishReceived> (message, clientId, channel).ConfigureAwait (continueOnCapturedContext: false);
 				await channel.Receiver
 					.ObserveOn (NewThreadScheduler.Default)
 					.OfType<PublishComplete> ()
@@ -73,12 +73,12 @@ namespace System.Net.Mqtt.Flows
 			}
 		}
 
-		protected void RemovePendingMessage(string clientId, ushort packetId)
+		protected void RemovePendingMessage (string clientId, ushort packetId)
 		{
-			var session = this.sessionRepository.Get (s => s.ClientId == clientId);
+			var session = sessionRepository.Get (s => s.ClientId == clientId);
 
 			if (session == null) {
-				throw new MqttException (string.Format(Properties.Resources.SessionRepository_ClientSessionNotFound, clientId));
+				throw new MqttException (string.Format (Properties.Resources.SessionRepository_ClientSessionNotFound, clientId));
 			}
 
 			var pendingMessage = session
@@ -87,27 +87,27 @@ namespace System.Net.Mqtt.Flows
 
 			session.RemovePendingMessage (pendingMessage);
 
-			this.sessionRepository.Update (session);
+			sessionRepository.Update (session);
 		}
 
-		protected async Task MonitorAckAsync<T>(Publish sentMessage, string clientId, IChannel<IPacket> channel)
+		protected async Task MonitorAckAsync<T> (Publish sentMessage, string clientId, IChannel<IPacket> channel)
 			where T : IFlowPacket
 		{
 			var intervalSubscription = Observable
-				.Interval (TimeSpan.FromSeconds (this.configuration.WaitingTimeoutSecs), NewThreadScheduler.Default)
+				.Interval (TimeSpan.FromSeconds (configuration.WaitingTimeoutSecs), NewThreadScheduler.Default)
 				.Subscribe (async _ => {
 					if (channel.IsConnected) {
 						tracer.Warn (Properties.Resources.Tracer_PublishFlow_RetryingQoSFlow, sentMessage.Type, clientId);
 
 						var duplicated = new Publish (sentMessage.Topic, sentMessage.QualityOfService,
 							sentMessage.Retain, duplicated: true, packetId: sentMessage.PacketId) {
-								Payload = sentMessage.Payload
-							};
+							Payload = sentMessage.Payload
+						};
 
 						await channel.SendAsync (duplicated);
 					}
 				});
-			
+
 			await channel.Receiver
 				.ObserveOn (NewThreadScheduler.Default)
 				.OfType<T> ()
@@ -116,39 +116,39 @@ namespace System.Net.Mqtt.Flows
 			intervalSubscription.Dispose ();
 		}
 
-		private void DefineSenderRules ()
+		void DefineSenderRules ()
 		{
-			this.senderRules = new Dictionary<PacketType, Func<string, ushort, IFlowPacket>> ();
+			senderRules = new Dictionary<PacketType, Func<string, ushort, IFlowPacket>> ();
 
-			this.senderRules.Add (PacketType.PublishAck, (clientId, packetId) => {
-				this.RemovePendingMessage (clientId, packetId);
+			senderRules.Add (PacketType.PublishAck, (clientId, packetId) => {
+				RemovePendingMessage (clientId, packetId);
 
 				return default (IFlowPacket);
 			});
 
-			this.senderRules.Add (PacketType.PublishReceived, (clientId, packetId) => {
-				this.RemovePendingMessage (clientId, packetId);
+			senderRules.Add (PacketType.PublishReceived, (clientId, packetId) => {
+				RemovePendingMessage (clientId, packetId);
 
-				return new PublishRelease(packetId);
+				return new PublishRelease (packetId);
 			});
 
-			this.senderRules.Add (PacketType.PublishComplete, (clientId, packetId) => {
-				this.RemovePendingAcknowledgement (clientId, packetId, PacketType.PublishRelease);
+			senderRules.Add (PacketType.PublishComplete, (clientId, packetId) => {
+				RemovePendingAcknowledgement (clientId, packetId, PacketType.PublishRelease);
 
 				return default (IFlowPacket);
 			});
 		}
 
-		private void SaveMessage(Publish message, string clientId, PendingMessageStatus status)
+		void SaveMessage (Publish message, string clientId, PendingMessageStatus status)
 		{
 			if (message.QualityOfService == QualityOfService.AtMostOnce) {
 				return;
 			}
 
-			var session = this.sessionRepository.Get (s => s.ClientId == clientId);
+			var session = sessionRepository.Get (s => s.ClientId == clientId);
 
 			if (session == null) {
-				throw new MqttException (string.Format(Properties.Resources.SessionRepository_ClientSessionNotFound, clientId));
+				throw new MqttException (string.Format (Properties.Resources.SessionRepository_ClientSessionNotFound, clientId));
 			}
 
 			var savedMessage = new PendingMessage {
@@ -163,7 +163,7 @@ namespace System.Net.Mqtt.Flows
 
 			session.AddPendingMessage (savedMessage);
 
-			this.sessionRepository.Update (session);
+			sessionRepository.Update (session);
 		}
 	}
 }

--- a/src/Core/Formatters/ConnectAckFormatter.cs
+++ b/src/Core/Formatters/ConnectAckFormatter.cs
@@ -9,10 +9,10 @@ namespace System.Net.Mqtt.Formatters
 
 		protected override ConnectAck Read (byte[] bytes)
 		{
-			this.ValidateHeaderFlag (bytes, t => t == PacketType.ConnectAck, 0x00);
+			ValidateHeaderFlag (bytes, t => t == PacketType.ConnectAck, 0x00);
 
 			var remainingLengthBytesLength = 0;
-			
+
 			Protocol.Encoding.DecodeRemainingLength (bytes, out remainingLengthBytesLength);
 
 			var connectAckFlagsIndex = Protocol.PacketTypeLength + remainingLengthBytesLength;
@@ -33,18 +33,18 @@ namespace System.Net.Mqtt.Formatters
 
 		protected override byte[] Write (ConnectAck packet)
 		{
-			var variableHeader = this.GetVariableHeader (packet);
+			var variableHeader = GetVariableHeader (packet);
 			var remainingLength = Protocol.Encoding.EncodeRemainingLength (variableHeader.Length);
-			var fixedHeader = this.GetFixedHeader (remainingLength);
+			var fixedHeader = GetFixedHeader (remainingLength);
 			var bytes = new byte[fixedHeader.Length + variableHeader.Length];
 
-			fixedHeader.CopyTo(bytes, 0);
-			variableHeader.CopyTo(bytes, fixedHeader.Length);
+			fixedHeader.CopyTo (bytes, 0);
+			variableHeader.CopyTo (bytes, fixedHeader.Length);
 
 			return bytes;
 		}
 
-		private byte[] GetFixedHeader(byte[] remainingLength)
+		byte[] GetFixedHeader (byte[] remainingLength)
 		{
 			var flags = 0x00;
 			var type = Convert.ToInt32(PacketType.ConnectAck) << 4;
@@ -52,12 +52,12 @@ namespace System.Net.Mqtt.Formatters
 			var fixedHeader = new byte[remainingLength.Length + 1];
 
 			fixedHeader[0] = fixedHeaderByte1;
-			remainingLength.CopyTo(fixedHeader, 1);
+			remainingLength.CopyTo (fixedHeader, 1);
 
 			return fixedHeader;
 		}
 
-		private byte[] GetVariableHeader(ConnectAck packet)
+		byte[] GetVariableHeader (ConnectAck packet)
 		{
 			if (packet.Status != ConnectionStatus.Accepted && packet.SessionPresent)
 				throw new MqttException (Properties.Resources.ConnectAckFormatter_InvalidSessionPresentForErrorReturnCode);

--- a/src/Core/Formatters/ConnectFormatter.cs
+++ b/src/Core/Formatters/ConnectFormatter.cs
@@ -11,10 +11,10 @@ namespace System.Net.Mqtt.Formatters
 
 		protected override Connect Read (byte[] bytes)
 		{
-			this.ValidateHeaderFlag (bytes, t => t == PacketType.Connect, 0x00);
+			ValidateHeaderFlag (bytes, t => t == PacketType.Connect, 0x00);
 
 			var remainingLengthBytesLength = 0;
-			
+
 			Protocol.Encoding.DecodeRemainingLength (bytes, out remainingLengthBytesLength);
 
 			var protocolName = bytes.GetString (Protocol.PacketTypeLength + remainingLengthBytesLength);
@@ -52,7 +52,7 @@ namespace System.Net.Mqtt.Formatters
 
 			var userNameFlag = connectFlags.IsSet (7);
 			var passwordFlag = connectFlags.IsSet (6);
-			
+
 			if (!userNameFlag && passwordFlag)
 				throw new MqttException (Properties.Resources.ConnectFormatter_InvalidPasswordFlag);
 
@@ -73,7 +73,7 @@ namespace System.Net.Mqtt.Formatters
 			if (clientId.Length > Protocol.ClientIdMaxLength)
 				throw new MqttConnectionException (ConnectionStatus.IdentifierRejected, Properties.Resources.ConnectFormatter_ClientIdMaxLengthExceeded);
 
-			if (!this.IsValidClientId (clientId)) {
+			if (!IsValidClientId (clientId)) {
 				var error = string.Format (Properties.Resources.ConnectFormatter_InvalidClientIdFormat, clientId);
 
 				throw new MqttConnectionException (ConnectionStatus.IdentifierRejected, error);
@@ -110,19 +110,19 @@ namespace System.Net.Mqtt.Formatters
 		{
 			var bytes = new List<byte> ();
 
-			var variableHeader = this.GetVariableHeader (packet);
-			var payload = this.GetPayload (packet);
+			var variableHeader = GetVariableHeader (packet);
+			var payload = GetPayload (packet);
 			var remainingLength = Protocol.Encoding.EncodeRemainingLength (variableHeader.Length + payload.Length);
-			var fixedHeader = this.GetFixedHeader (remainingLength);
+			var fixedHeader = GetFixedHeader (remainingLength);
 
 			bytes.AddRange (fixedHeader);
 			bytes.AddRange (variableHeader);
 			bytes.AddRange (payload);
 
-			return bytes.ToArray();
+			return bytes.ToArray ();
 		}
 
-		private byte[] GetFixedHeader(byte[] remainingLength)
+		byte[] GetFixedHeader (byte[] remainingLength)
 		{
 			var fixedHeader = new List<byte> ();
 
@@ -134,10 +134,10 @@ namespace System.Net.Mqtt.Formatters
 			fixedHeader.Add (fixedHeaderByte1);
 			fixedHeader.AddRange (remainingLength);
 
-			return fixedHeader.ToArray();
+			return fixedHeader.ToArray ();
 		}
 
-		private byte[] GetVariableHeader(Connect packet)
+		byte[] GetVariableHeader (Connect packet)
 		{
 			var variableHeader = new List<byte> ();
 
@@ -171,10 +171,10 @@ namespace System.Net.Mqtt.Formatters
 			variableHeader.Add (keepAliveBytes[keepAliveBytes.Length - 2]);
 			variableHeader.Add (keepAliveBytes[keepAliveBytes.Length - 1]);
 
-			return variableHeader.ToArray();
+			return variableHeader.ToArray ();
 		}
 
-		private byte[] GetPayload(Connect packet)
+		byte[] GetPayload (Connect packet)
 		{
 			if (string.IsNullOrEmpty (packet.ClientId))
 				throw new MqttException (Properties.Resources.ConnectFormatter_ClientIdRequired);
@@ -182,7 +182,7 @@ namespace System.Net.Mqtt.Formatters
 			if (packet.ClientId.Length > Protocol.ClientIdMaxLength)
 				throw new MqttException (Properties.Resources.ConnectFormatter_ClientIdMaxLengthExceeded);
 
-			if (!this.IsValidClientId (packet.ClientId)) {
+			if (!IsValidClientId (packet.ClientId)) {
 				var error = string.Format (Properties.Resources.ConnectFormatter_InvalidClientIdFormat, packet.ClientId);
 
 				throw new MqttException (error);
@@ -192,7 +192,7 @@ namespace System.Net.Mqtt.Formatters
 
 			var clientIdBytes = Protocol.Encoding.EncodeString(packet.ClientId);
 
-			payload.AddRange(clientIdBytes);
+			payload.AddRange (clientIdBytes);
 
 			if (packet.Will != null) {
 				var willTopicBytes = Protocol.Encoding.EncodeString(packet.Will.Topic);
@@ -220,7 +220,7 @@ namespace System.Net.Mqtt.Formatters
 			return payload.ToArray ();
 		}
 
-		private bool IsValidClientId(string clientId)
+		bool IsValidClientId (string clientId)
 		{
 			var regex = new Regex ("^[a-zA-Z0-9]+$");
 

--- a/src/Core/Formatters/EmptyPacketFormatter.cs
+++ b/src/Core/Formatters/EmptyPacketFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace System.Net.Mqtt.Formatters
 {
-	internal class EmptyPacketFormatter <T> : Formatter<T>
+	internal class EmptyPacketFormatter<T> : Formatter<T>
 		where T : class, IPacket, new()
 	{
 		readonly PacketType packetType;
@@ -12,19 +12,19 @@ namespace System.Net.Mqtt.Formatters
 			this.packetType = packetType;
 		}
 
-		public override PacketType PacketType { get { return this.packetType; } }
+		public override PacketType PacketType { get { return packetType; } }
 
 		protected override T Read (byte[] bytes)
 		{
-			this.ValidateHeaderFlag (bytes, t => t == this.packetType, 0x00);
+			ValidateHeaderFlag (bytes, t => t == packetType, 0x00);
 
-			return new T();
+			return new T ();
 		}
 
 		protected override byte[] Write (T packet)
 		{
 			var flags = 0x00;
-			var type = Convert.ToInt32(this.packetType) << 4;
+			var type = Convert.ToInt32(packetType) << 4;
 
 			var fixedHeaderByte1 = Convert.ToByte(flags | type);
 			var fixedHeaderByte2 = Convert.ToByte (0x00);

--- a/src/Core/Formatters/FlowPacketFormatter.cs
+++ b/src/Core/Formatters/FlowPacketFormatter.cs
@@ -8,7 +8,7 @@ namespace System.Net.Mqtt.Formatters
 		readonly PacketType packetType;
 		readonly Func<ushort, T> packetFactory;
 
-		public FlowPacketFormatter(PacketType packetType, Func<ushort, T> packetFactory)
+		public FlowPacketFormatter (PacketType packetType, Func<ushort, T> packetFactory)
 		{
 			this.packetType = packetType;
 			this.packetFactory = packetFactory;
@@ -16,35 +16,35 @@ namespace System.Net.Mqtt.Formatters
 
 		public override PacketType PacketType { get { return packetType; } }
 
-		protected override T Read(byte[] bytes)
+		protected override T Read (byte[] bytes)
 		{
-			this.ValidateHeaderFlag (bytes, t => t == PacketType.PublishRelease, 0x02);
-			this.ValidateHeaderFlag (bytes, t => t != PacketType.PublishRelease, 0x00);
+			ValidateHeaderFlag (bytes, t => t == PacketType.PublishRelease, 0x02);
+			ValidateHeaderFlag (bytes, t => t != PacketType.PublishRelease, 0x00);
 
 			var remainingLengthBytesLength = 0;
-			
+
 			Protocol.Encoding.DecodeRemainingLength (bytes, out remainingLengthBytesLength);
 
 			var packetIdIndex = Protocol.PacketTypeLength + remainingLengthBytesLength;
 			var packetIdBytes = bytes.Bytes (packetIdIndex, 2);
 
-			return packetFactory(packetIdBytes.ToUInt16 ());
+			return packetFactory (packetIdBytes.ToUInt16 ());
 		}
 
-		protected override byte[] Write(T packet)
+		protected override byte[] Write (T packet)
 		{
 			var variableHeader = Protocol.Encoding.EncodeInteger(packet.PacketId);
 			var remainingLength = Protocol.Encoding.EncodeRemainingLength (variableHeader.Length);
-			var fixedHeader = this.GetFixedHeader (packet.Type, remainingLength);
+			var fixedHeader = GetFixedHeader (packet.Type, remainingLength);
 			var bytes = new byte[fixedHeader.Length + variableHeader.Length];
 
-			fixedHeader.CopyTo(bytes, 0);
-			variableHeader.CopyTo(bytes, fixedHeader.Length);
+			fixedHeader.CopyTo (bytes, 0);
+			variableHeader.CopyTo (bytes, fixedHeader.Length);
 
 			return bytes;
 		}
 
-		private byte[] GetFixedHeader(PacketType packetType, byte[] remainingLength)
+		byte[] GetFixedHeader (PacketType packetType, byte[] remainingLength)
 		{
 			// MQTT 2.2.2: http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/csprd02/mqtt-v3.1.1-csprd02.html#_Toc385349758
 			// The flags for PUBREL are different than for the other flow packets.
@@ -54,7 +54,7 @@ namespace System.Net.Mqtt.Formatters
 			var fixedHeader = new byte[1 + remainingLength.Length];
 
 			fixedHeader[0] = fixedHeaderByte1;
-			remainingLength.CopyTo(fixedHeader, 1);
+			remainingLength.CopyTo (fixedHeader, 1);
 
 			return fixedHeader;
 		}

--- a/src/Core/Formatters/Formatter.cs
+++ b/src/Core/Formatters/Formatter.cs
@@ -26,7 +26,7 @@ namespace System.Net.Mqtt.Formatters
 				throw new MqttException (error);
 			}
 
-			var packet = await Task.Run(() => this.Read (bytes))
+			var packet = await Task.Run(() => Read (bytes))
 				.ConfigureAwait(continueOnCapturedContext: false);
 
 			return packet;
@@ -43,7 +43,7 @@ namespace System.Net.Mqtt.Formatters
 				throw new MqttException (error);
 			}
 
-			var bytes = await Task.Run(() => this.Write (packet as T))
+			var bytes = await Task.Run(() => Write (packet as T))
 				.ConfigureAwait(continueOnCapturedContext: false);
 
 			return bytes;
@@ -53,7 +53,7 @@ namespace System.Net.Mqtt.Formatters
 		{
 			var headerFlag = bytes.Byte (0).Bits (5, 4);
 
-			if (packetTypePredicate(this.PacketType) && headerFlag != expectedFlag) {
+			if (packetTypePredicate (PacketType) && headerFlag != expectedFlag) {
 				var error = string.Format (Properties.Resources.Formatter_InvalidHeaderFlag, headerFlag, typeof(T).Name, expectedFlag);
 
 				throw new MqttException (error);

--- a/src/Core/Formatters/PublishFormatter.cs
+++ b/src/Core/Formatters/PublishFormatter.cs
@@ -37,7 +37,7 @@ namespace System.Net.Mqtt.Formatters
 			var nextIndex = 0;
 			var topic = bytes.GetString (topicStartIndex, out nextIndex);
 
-			if (!this.topicEvaluator.IsValidTopicName (topic)) {
+			if (!topicEvaluator.IsValidTopicName (topic)) {
 				var error = string.Format(Properties.Resources.PublishFormatter_InvalidTopicName, topic);
 
 				throw new MqttException (error);
@@ -66,10 +66,10 @@ namespace System.Net.Mqtt.Formatters
 		{
 			var bytes = new List<byte> ();
 
-			var variableHeader = this.GetVariableHeader (packet);
+			var variableHeader = GetVariableHeader (packet);
 			var payloadLength = packet.Payload == null ? 0 : packet.Payload.Length;
 			var remainingLength = Protocol.Encoding.EncodeRemainingLength (variableHeader.Length + payloadLength);
-			var fixedHeader = this.GetFixedHeader (packet, remainingLength);
+			var fixedHeader = GetFixedHeader (packet, remainingLength);
 
 			bytes.AddRange (fixedHeader);
 			bytes.AddRange (variableHeader);
@@ -78,10 +78,10 @@ namespace System.Net.Mqtt.Formatters
 				bytes.AddRange (packet.Payload);
 			}
 
-			return bytes.ToArray();
+			return bytes.ToArray ();
 		}
 
-		private byte[] GetFixedHeader(Publish packet, byte[] remainingLength)
+		byte[] GetFixedHeader (Publish packet, byte[] remainingLength)
 		{
 			if (packet.QualityOfService == QualityOfService.AtMostOnce && packet.Duplicated)
 				throw new MqttException (Properties.Resources.PublishFormatter_InvalidDuplicatedWithQoSZero);
@@ -103,18 +103,18 @@ namespace System.Net.Mqtt.Formatters
 			fixedHeader.Add (fixedHeaderByte1);
 			fixedHeader.AddRange (remainingLength);
 
-			return fixedHeader.ToArray();
+			return fixedHeader.ToArray ();
 		}
 
-		private byte[] GetVariableHeader(Publish packet)
+		byte[] GetVariableHeader (Publish packet)
 		{
-			if (!this.topicEvaluator.IsValidTopicName (packet.Topic))
+			if (!topicEvaluator.IsValidTopicName (packet.Topic))
 				throw new MqttException (Properties.Resources.PublishFormatter_InvalidTopicName);
 
 			if (packet.PacketId.HasValue && packet.QualityOfService == QualityOfService.AtMostOnce)
-					throw new MqttException (Properties.Resources.PublishFormatter_InvalidPacketId);
+				throw new MqttException (Properties.Resources.PublishFormatter_InvalidPacketId);
 
-			if(!packet.PacketId.HasValue && packet.QualityOfService != QualityOfService.AtMostOnce)
+			if (!packet.PacketId.HasValue && packet.QualityOfService != QualityOfService.AtMostOnce)
 				throw new MqttException (Properties.Resources.PublishFormatter_PacketIdRequired);
 
 			var variableHeader = new List<byte> ();
@@ -129,7 +129,7 @@ namespace System.Net.Mqtt.Formatters
 				variableHeader.AddRange (packetIdBytes);
 			}
 
-			return variableHeader.ToArray();
+			return variableHeader.ToArray ();
 		}
 	}
 }

--- a/src/Core/Formatters/SubscribeAckFormatter.cs
+++ b/src/Core/Formatters/SubscribeAckFormatter.cs
@@ -11,7 +11,7 @@ namespace System.Net.Mqtt.Formatters
 
 		protected override SubscribeAck Read (byte[] bytes)
 		{
-			this.ValidateHeaderFlag (bytes, t => t == PacketType.SubscribeAck, 0x00);
+			ValidateHeaderFlag (bytes, t => t == PacketType.SubscribeAck, 0x00);
 
 			var remainingLengthBytesLength = 0;
 			var remainingLength = Protocol.Encoding.DecodeRemainingLength (bytes, out remainingLengthBytesLength);
@@ -22,12 +22,12 @@ namespace System.Net.Mqtt.Formatters
 			var headerLength = 1 + remainingLengthBytesLength + 2;
 			var returnCodeBytes = bytes.Bytes(headerLength);
 
-			if(!returnCodeBytes.Any())
-				throw new MqttViolationException(Properties.Resources.SubscribeAckFormatter_MissingReturnCodes);
+			if (!returnCodeBytes.Any ())
+				throw new MqttViolationException (Properties.Resources.SubscribeAckFormatter_MissingReturnCodes);
 
 			if (returnCodeBytes.Any (b => !Enum.IsDefined (typeof (SubscribeReturnCode), b)))
 				throw new MqttViolationException (Properties.Resources.SubscribeAckFormatter_InvalidReturnCodes);
-				
+
 			var returnCodes = returnCodeBytes.Select(b => (SubscribeReturnCode)b).ToArray();
 
 			return new SubscribeAck (packetIdentifier, returnCodes);
@@ -37,19 +37,19 @@ namespace System.Net.Mqtt.Formatters
 		{
 			var bytes = new List<byte> ();
 
-			var variableHeader = this.GetVariableHeader (packet);
-			var payload = this.GetPayload (packet);
+			var variableHeader = GetVariableHeader (packet);
+			var payload = GetPayload (packet);
 			var remainingLength = Protocol.Encoding.EncodeRemainingLength (variableHeader.Length + payload.Length);
-			var fixedHeader = this.GetFixedHeader (remainingLength);
+			var fixedHeader = GetFixedHeader (remainingLength);
 
 			bytes.AddRange (fixedHeader);
 			bytes.AddRange (variableHeader);
 			bytes.AddRange (payload);
 
-			return bytes.ToArray();
+			return bytes.ToArray ();
 		}
 
-		private byte[] GetFixedHeader(byte[] remainingLength)
+		byte[] GetFixedHeader (byte[] remainingLength)
 		{
 			var fixedHeader = new List<byte> ();
 
@@ -61,10 +61,10 @@ namespace System.Net.Mqtt.Formatters
 			fixedHeader.Add (fixedHeaderByte1);
 			fixedHeader.AddRange (remainingLength);
 
-			return fixedHeader.ToArray();
+			return fixedHeader.ToArray ();
 		}
 
-		private byte[] GetVariableHeader(SubscribeAck packet)
+		byte[] GetVariableHeader (SubscribeAck packet)
 		{
 			var variableHeader = new List<byte> ();
 
@@ -72,17 +72,17 @@ namespace System.Net.Mqtt.Formatters
 
 			variableHeader.AddRange (packetIdBytes);
 
-			return variableHeader.ToArray();
+			return variableHeader.ToArray ();
 		}
 
-		private byte[] GetPayload(SubscribeAck packet)
+		byte[] GetPayload (SubscribeAck packet)
 		{
-			if(packet.ReturnCodes == null || !packet.ReturnCodes.Any())
-				throw new MqttViolationException(Properties.Resources.SubscribeAckFormatter_MissingReturnCodes);
+			if (packet.ReturnCodes == null || !packet.ReturnCodes.Any ())
+				throw new MqttViolationException (Properties.Resources.SubscribeAckFormatter_MissingReturnCodes);
 
 			return packet.ReturnCodes
-				.Select(c => Convert.ToByte(c))
-				.ToArray();
+				.Select (c => Convert.ToByte (c))
+				.ToArray ();
 		}
 	}
 }

--- a/src/Core/Formatters/UnsubscribeFormatter.cs
+++ b/src/Core/Formatters/UnsubscribeFormatter.cs
@@ -11,7 +11,7 @@ namespace System.Net.Mqtt.Formatters
 
 		protected override Unsubscribe Read (byte[] bytes)
 		{
-			this.ValidateHeaderFlag (bytes, t => t == PacketType.Unsubscribe, 0x02);
+			ValidateHeaderFlag (bytes, t => t == PacketType.Unsubscribe, 0x02);
 
 			var remainingLengthBytesLength = 0;
 			var remainingLength = Protocol.Encoding.DecodeRemainingLength (bytes, out remainingLengthBytesLength);
@@ -32,26 +32,26 @@ namespace System.Net.Mqtt.Formatters
 				topics.Add (topic);
 			} while (bytes.Length - index + 1 >= 2);
 
-			return new Unsubscribe (packetIdentifier, topics.ToArray());
+			return new Unsubscribe (packetIdentifier, topics.ToArray ());
 		}
 
 		protected override byte[] Write (Unsubscribe packet)
 		{
 			var bytes = new List<byte> ();
 
-			var variableHeader = this.GetVariableHeader (packet);
-			var payload = this.GetPayload (packet);
+			var variableHeader = GetVariableHeader (packet);
+			var payload = GetPayload (packet);
 			var remainingLength = Protocol.Encoding.EncodeRemainingLength (variableHeader.Length + payload.Length);
-			var fixedHeader = this.GetFixedHeader (remainingLength);
+			var fixedHeader = GetFixedHeader (remainingLength);
 
 			bytes.AddRange (fixedHeader);
 			bytes.AddRange (variableHeader);
 			bytes.AddRange (payload);
 
-			return bytes.ToArray();
+			return bytes.ToArray ();
 		}
 
-		private byte[] GetFixedHeader(byte[] remainingLength)
+		byte[] GetFixedHeader (byte[] remainingLength)
 		{
 			var fixedHeader = new List<byte> ();
 
@@ -63,10 +63,10 @@ namespace System.Net.Mqtt.Formatters
 			fixedHeader.Add (fixedHeaderByte1);
 			fixedHeader.AddRange (remainingLength);
 
-			return fixedHeader.ToArray();
+			return fixedHeader.ToArray ();
 		}
 
-		private byte[] GetVariableHeader(Unsubscribe packet)
+		byte[] GetVariableHeader (Unsubscribe packet)
 		{
 			var variableHeader = new List<byte> ();
 
@@ -74,12 +74,12 @@ namespace System.Net.Mqtt.Formatters
 
 			variableHeader.AddRange (packetIdBytes);
 
-			return variableHeader.ToArray();
+			return variableHeader.ToArray ();
 		}
 
-		private byte[] GetPayload(Unsubscribe packet)
+		byte[] GetPayload (Unsubscribe packet)
 		{
-			if(packet.Topics == null || !packet.Topics.Any())
+			if (packet.Topics == null || !packet.Topics.Any ())
 				throw new MqttViolationException (Properties.Resources.UnsubscribeFormatter_MissingTopics);
 
 			var payload = new List<byte> ();

--- a/src/Core/IChannel.cs
+++ b/src/Core/IChannel.cs
@@ -3,14 +3,14 @@
 namespace System.Net.Mqtt
 {
 	public interface IChannel<T> : IDisposable
-    {
+	{
 		bool IsConnected { get; }
 
-        IObservable<T> Receiver { get; }
+		IObservable<T> Receiver { get; }
 
 		IObservable<T> Sender { get; }
 
 		/// <exception cref="ProtocolException">ProtocolException</exception>
-        Task SendAsync(T message);
-    }
+		Task SendAsync (T message);
+	}
 }

--- a/src/Core/PacketChannelFactory.cs
+++ b/src/Core/PacketChannelFactory.cs
@@ -12,7 +12,7 @@ namespace System.Net.Mqtt
 		readonly ProtocolConfiguration configuration;
 
 		public PacketChannelFactory (IChannelFactory innerChannelFactory, ITopicEvaluator topicEvaluator, ProtocolConfiguration configuration)
-			: this(topicEvaluator, configuration)
+			: this (topicEvaluator, configuration)
 		{
 			this.innerChannelFactory = innerChannelFactory;
 		}
@@ -25,38 +25,38 @@ namespace System.Net.Mqtt
 
 		public IChannel<IPacket> Create ()
 		{
-			if (this.innerChannelFactory == null) {
+			if (innerChannelFactory == null) {
 				throw new MqttException (Properties.Resources.PacketChannelFactory_InnerChannelFactoryNotFound);
 			}
 
-			var binaryChannel = this.innerChannelFactory.Create ();
+			var binaryChannel = innerChannelFactory.Create ();
 
-			return this.Create (binaryChannel);
+			return Create (binaryChannel);
 		}
 
 		public IChannel<IPacket> Create (IChannel<byte[]> binaryChannel)
 		{
-			var formatters = this.GetFormatters();
+			var formatters = GetFormatters();
 			var manager = new PacketManager (formatters);
 
-			return new PacketChannel (binaryChannel, manager, this.configuration);
+			return new PacketChannel (binaryChannel, manager, configuration);
 		}
 
-		private IEnumerable<IFormatter> GetFormatters()
+		IEnumerable<IFormatter> GetFormatters ()
 		{
 			var formatters = new List<IFormatter> ();
-			
+
 			formatters.Add (new ConnectFormatter ());
 			formatters.Add (new ConnectAckFormatter ());
-			formatters.Add (new PublishFormatter (this.topicEvaluator));
-			formatters.Add (new FlowPacketFormatter<PublishAck>(PacketType.PublishAck, id => new PublishAck(id)));
-			formatters.Add (new FlowPacketFormatter<PublishReceived>(PacketType.PublishReceived, id => new PublishReceived(id)));
-			formatters.Add (new FlowPacketFormatter<PublishRelease>(PacketType.PublishRelease, id => new PublishRelease(id)));
-			formatters.Add (new FlowPacketFormatter<PublishComplete>(PacketType.PublishComplete, id => new PublishComplete(id)));
-			formatters.Add (new SubscribeFormatter (this.topicEvaluator));
+			formatters.Add (new PublishFormatter (topicEvaluator));
+			formatters.Add (new FlowPacketFormatter<PublishAck> (PacketType.PublishAck, id => new PublishAck (id)));
+			formatters.Add (new FlowPacketFormatter<PublishReceived> (PacketType.PublishReceived, id => new PublishReceived (id)));
+			formatters.Add (new FlowPacketFormatter<PublishRelease> (PacketType.PublishRelease, id => new PublishRelease (id)));
+			formatters.Add (new FlowPacketFormatter<PublishComplete> (PacketType.PublishComplete, id => new PublishComplete (id)));
+			formatters.Add (new SubscribeFormatter (topicEvaluator));
 			formatters.Add (new SubscribeAckFormatter ());
 			formatters.Add (new UnsubscribeFormatter ());
-			formatters.Add (new FlowPacketFormatter<UnsubscribeAck> (PacketType.UnsubscribeAck, id => new UnsubscribeAck(id)));
+			formatters.Add (new FlowPacketFormatter<UnsubscribeAck> (PacketType.UnsubscribeAck, id => new UnsubscribeAck (id)));
 			formatters.Add (new EmptyPacketFormatter<PingRequest> (PacketType.PingRequest));
 			formatters.Add (new EmptyPacketFormatter<PingResponse> (PacketType.PingResponse));
 			formatters.Add (new EmptyPacketFormatter<Disconnect> (PacketType.Disconnect));

--- a/src/Core/PacketIdProvider.cs
+++ b/src/Core/PacketIdProvider.cs
@@ -2,26 +2,26 @@
 {
 	internal class PacketIdProvider : IPacketIdProvider
 	{
-		private readonly object lockObject;
-		private volatile ushort lastValue;
+		readonly object lockObject;
+		volatile ushort lastValue;
 
 		public PacketIdProvider ()
 		{
-			this.lockObject = new object ();
-			this.lastValue = 0;
+			lockObject = new object ();
+			lastValue = 0;
 		}
 
 		public ushort GetPacketId ()
 		{
 			var id = default (ushort);
 
-			lock (this.lockObject) {
+			lock (lockObject) {
 				if (lastValue == ushort.MaxValue) {
 					id = 1;
 				} else {
 					id = (ushort)(lastValue + 1);
 				}
-				
+
 				lastValue = id;
 			}
 

--- a/src/Core/PacketManager.cs
+++ b/src/Core/PacketManager.cs
@@ -12,13 +12,13 @@ namespace System.Net.Mqtt
 		readonly IDictionary<PacketType, IFormatter> formatters;
 
 		public PacketManager (params IFormatter[] formatters)
-			: this((IEnumerable<IFormatter>)formatters)
+			: this ((IEnumerable<IFormatter>)formatters)
 		{
 		}
 
 		public PacketManager (IEnumerable<IFormatter> formatters)
 		{
-			this.formatters = formatters.ToDictionary(f => f.PacketType);
+			this.formatters = formatters.ToDictionary (f => f.PacketType);
 		}
 
 		/// <exception cref="MqttConnectionException">ConnectProtocolException</exception>
@@ -29,7 +29,7 @@ namespace System.Net.Mqtt
 			var packetType = (PacketType)bytes.Byte (0).Bits (4);
 			var formatter = default (IFormatter);
 
-			if (!formatters.TryGetValue(packetType, out formatter))
+			if (!formatters.TryGetValue (packetType, out formatter))
 				throw new MqttException (Properties.Resources.PacketManager_PacketUnknown);
 
 			var packet = await formatter.FormatAsync (bytes)
@@ -45,7 +45,7 @@ namespace System.Net.Mqtt
 		{
 			var formatter = default (IFormatter);
 
-			if (!formatters.TryGetValue(packet.Type, out formatter))
+			if (!formatters.TryGetValue (packet.Type, out formatter))
 				throw new MqttException (Properties.Resources.PacketManager_PacketUnknown);
 
 			var bytes = await formatter.FormatAsync (packet)

--- a/src/Core/Packets/Connect.cs
+++ b/src/Core/Packets/Connect.cs
@@ -8,18 +8,18 @@
 				throw new ArgumentNullException ("clientId");
 			}
 
-			this.ClientId = clientId;
-			this.CleanSession = cleanSession;
-			this.KeepAlive = 0;
+			ClientId = clientId;
+			CleanSession = cleanSession;
+			KeepAlive = 0;
 		}
 
 		public Connect ()
 		{
-			this.CleanSession = true;
-			this.KeepAlive = 0;
+			CleanSession = true;
+			KeepAlive = 0;
 		}
 
-		public PacketType Type { get { return PacketType.Connect; }}
+		public PacketType Type { get { return PacketType.Connect; } }
 
 		public string ClientId { get; set; }
 
@@ -29,21 +29,21 @@
 
 		public Will Will { get; set; }
 
-        public string UserName { get; set; }
+		public string UserName { get; set; }
 
-        public string Password { get; set; }
+		public string Password { get; set; }
 
 		public bool Equals (Connect other)
 		{
 			if (other == null)
 				return false;
 
-			return this.ClientId == other.ClientId &&
-				this.CleanSession == other.CleanSession &&
-				this.KeepAlive == other.KeepAlive &&
-				this.Will == other.Will &&
-				this.UserName == other.UserName &&
-				this.Password == other.Password;
+			return ClientId == other.ClientId &&
+				CleanSession == other.CleanSession &&
+				KeepAlive == other.KeepAlive &&
+				Will == other.Will &&
+				UserName == other.UserName &&
+				Password == other.Password;
 		}
 
 		public override bool Equals (object obj)
@@ -56,28 +56,28 @@
 			if (connect == null)
 				return false;
 
-			return this.Equals (connect);
+			return Equals (connect);
 		}
 
 		public static bool operator == (Connect connect, Connect other)
 		{
 			if ((object)connect == null || (object)other == null)
-				return Object.Equals(connect, other);
+				return Object.Equals (connect, other);
 
-			return connect.Equals(other);
+			return connect.Equals (other);
 		}
 
 		public static bool operator != (Connect connect, Connect other)
 		{
 			if ((object)connect == null || (object)other == null)
-				return !Object.Equals(connect, other);
+				return !Object.Equals (connect, other);
 
-			return !connect.Equals(other);
+			return !connect.Equals (other);
 		}
 
 		public override int GetHashCode ()
 		{
-			return this.ClientId.GetHashCode ();
+			return ClientId.GetHashCode ();
 		}
 	}
 }

--- a/src/Core/Packets/ConnectAck.cs
+++ b/src/Core/Packets/ConnectAck.cs
@@ -1,16 +1,16 @@
 ﻿namespace System.Net.Mqtt.Packets
 {
 	internal class ConnectAck : IPacket, IEquatable<ConnectAck>
-    {
-        public ConnectAck(ConnectionStatus status, bool existingSession)
-        {
-            this.Status = status;
-			this.SessionPresent = existingSession;
-        }
+	{
+		public ConnectAck (ConnectionStatus status, bool existingSession)
+		{
+			Status = status;
+			SessionPresent = existingSession;
+		}
 
-		public PacketType Type { get { return PacketType.ConnectAck; }}
+		public PacketType Type { get { return PacketType.ConnectAck; } }
 
-        public ConnectionStatus Status { get; private set; }
+		public ConnectionStatus Status { get; private set; }
 
 		public bool SessionPresent { get; private set; }
 
@@ -19,8 +19,8 @@
 			if (other == null)
 				return false;
 
-			return this.Status == other.Status &&
-				this.SessionPresent == other.SessionPresent;
+			return Status == other.Status &&
+				SessionPresent == other.SessionPresent;
 		}
 
 		public override bool Equals (object obj)
@@ -33,28 +33,28 @@
 			if (connectAck == null)
 				return false;
 
-			return this.Equals (connectAck);
+			return Equals (connectAck);
 		}
 
 		public static bool operator == (ConnectAck connectAck, ConnectAck other)
 		{
 			if ((object)connectAck == null || (object)other == null)
-				return Object.Equals(connectAck, other);
+				return Object.Equals (connectAck, other);
 
-			return connectAck.Equals(other);
+			return connectAck.Equals (other);
 		}
 
 		public static bool operator != (ConnectAck connectAck, ConnectAck other)
 		{
 			if ((object)connectAck == null || (object)other == null)
-				return !Object.Equals(connectAck, other);
+				return !Object.Equals (connectAck, other);
 
-			return !connectAck.Equals(other);
+			return !connectAck.Equals (other);
 		}
 
 		public override int GetHashCode ()
 		{
-			return this.Status.GetHashCode () + this.SessionPresent.GetHashCode ();
+			return Status.GetHashCode () + SessionPresent.GetHashCode ();
 		}
 	}
 }

--- a/src/Core/Packets/Disconnect.cs
+++ b/src/Core/Packets/Disconnect.cs
@@ -1,7 +1,7 @@
 ﻿namespace System.Net.Mqtt.Packets
 {
 	internal class Disconnect : IPacket
-    {
-		public PacketType Type { get { return PacketType.Disconnect; }}
-    }
+	{
+		public PacketType Type { get { return PacketType.Disconnect; } }
+	}
 }

--- a/src/Core/Packets/PingRequest.cs
+++ b/src/Core/Packets/PingRequest.cs
@@ -1,7 +1,7 @@
 ﻿namespace System.Net.Mqtt.Packets
 {
 	internal class PingRequest : IPacket
-    {
-		public PacketType Type { get { return PacketType.PingRequest; }}
+	{
+		public PacketType Type { get { return PacketType.PingRequest; } }
 	}
 }

--- a/src/Core/Packets/PingResponse.cs
+++ b/src/Core/Packets/PingResponse.cs
@@ -1,7 +1,7 @@
 ﻿namespace System.Net.Mqtt.Packets
 {
 	internal class PingResponse : IPacket
-    {
-		public PacketType Type { get { return PacketType.PingResponse; }}
-    }
+	{
+		public PacketType Type { get { return PacketType.PingResponse; } }
+	}
 }

--- a/src/Core/Packets/Publish.cs
+++ b/src/Core/Packets/Publish.cs
@@ -3,17 +3,17 @@
 namespace System.Net.Mqtt.Packets
 {
 	internal class Publish : IPacket, IEquatable<Publish>
-    {
-        public Publish(string topic, QualityOfService qualityOfService, bool retain, bool duplicated, ushort? packetId = null)
-        {
-            this.QualityOfService = qualityOfService;
-			this.Duplicated = duplicated;
-			this.Retain = retain;
-			this.Topic = topic;
-            this.PacketId = packetId;
-        }
+	{
+		public Publish (string topic, QualityOfService qualityOfService, bool retain, bool duplicated, ushort? packetId = null)
+		{
+			QualityOfService = qualityOfService;
+			Duplicated = duplicated;
+			Retain = retain;
+			Topic = topic;
+			PacketId = packetId;
+		}
 
-		public PacketType Type { get { return PacketType.Publish; }}
+		public PacketType Type { get { return PacketType.Publish; } }
 
 		public QualityOfService QualityOfService { get; private set; }
 
@@ -21,9 +21,9 @@ namespace System.Net.Mqtt.Packets
 
 		public bool Retain { get; private set; }
 
-        public string Topic { get; private set; }
+		public string Topic { get; private set; }
 
-        public ushort? PacketId { get; private set; }
+		public ushort? PacketId { get; private set; }
 
 		public byte[] Payload { get; set; }
 
@@ -32,14 +32,14 @@ namespace System.Net.Mqtt.Packets
 			if (other == null)
 				return false;
 
-			var equals = this.QualityOfService == other.QualityOfService &&
-				this.Duplicated == other.Duplicated &&
-				this.Retain == other.Retain &&
-				this.Topic == other.Topic &&
-				this.PacketId == other.PacketId;
+			var equals = QualityOfService == other.QualityOfService &&
+				Duplicated == other.Duplicated &&
+				Retain == other.Retain &&
+				Topic == other.Topic &&
+				PacketId == other.PacketId;
 
-			if(this.Payload != null) {
-				equals &= this.Payload.ToList().SequenceEqual(other.Payload);
+			if (Payload != null) {
+				equals &= Payload.ToList ().SequenceEqual (other.Payload);
 			}
 
 			return equals;
@@ -55,38 +55,38 @@ namespace System.Net.Mqtt.Packets
 			if (publish == null)
 				return false;
 
-			return this.Equals (publish);
+			return Equals (publish);
 		}
 
 		public static bool operator == (Publish publish, Publish other)
 		{
 			if ((object)publish == null || (object)other == null)
-				return Object.Equals(publish, other);
+				return Object.Equals (publish, other);
 
-			return publish.Equals(other);
+			return publish.Equals (other);
 		}
 
 		public static bool operator != (Publish publish, Publish other)
 		{
 			if ((object)publish == null || (object)other == null)
-				return !Object.Equals(publish, other);
+				return !Object.Equals (publish, other);
 
-			return !publish.Equals(other);
+			return !publish.Equals (other);
 		}
 
 		public override int GetHashCode ()
 		{
-			var hashCode = this.QualityOfService.GetHashCode () +
-				this.Duplicated.GetHashCode () +
-				this.Retain.GetHashCode () +
-				this.Topic.GetHashCode ();
+			var hashCode = QualityOfService.GetHashCode () +
+				Duplicated.GetHashCode () +
+				Retain.GetHashCode () +
+				Topic.GetHashCode ();
 
-			if (this.Payload != null) {
-				hashCode += BitConverter.ToString (this.Payload).GetHashCode ();
+			if (Payload != null) {
+				hashCode += BitConverter.ToString (Payload).GetHashCode ();
 			}
 
-			if (this.PacketId.HasValue) {
-				hashCode += this.PacketId.Value.GetHashCode ();
+			if (PacketId.HasValue) {
+				hashCode += PacketId.Value.GetHashCode ();
 			}
 
 			return hashCode;

--- a/src/Core/Packets/PublishAck.cs
+++ b/src/Core/Packets/PublishAck.cs
@@ -1,22 +1,22 @@
 ﻿namespace System.Net.Mqtt.Packets
 {
 	internal class PublishAck : IFlowPacket, IEquatable<PublishAck>
-    {
-        public PublishAck(ushort packetId)
-        {
-            this.PacketId = packetId;
-        }
+	{
+		public PublishAck (ushort packetId)
+		{
+			PacketId = packetId;
+		}
 
-		public PacketType Type { get { return PacketType.PublishAck; }}
+		public PacketType Type { get { return PacketType.PublishAck; } }
 
-        public ushort PacketId { get; private set; }
+		public ushort PacketId { get; private set; }
 
 		public bool Equals (PublishAck other)
 		{
 			if (other == null)
 				return false;
 
-			return this.PacketId == other.PacketId;
+			return PacketId == other.PacketId;
 		}
 
 		public override bool Equals (object obj)
@@ -29,28 +29,28 @@
 			if (publishAck == null)
 				return false;
 
-			return this.Equals (publishAck);
+			return Equals (publishAck);
 		}
 
 		public static bool operator == (PublishAck publishAck, PublishAck other)
 		{
 			if ((object)publishAck == null || (object)other == null)
-				return Object.Equals(publishAck, other);
+				return Object.Equals (publishAck, other);
 
-			return publishAck.Equals(other);
+			return publishAck.Equals (other);
 		}
 
 		public static bool operator != (PublishAck publishAck, PublishAck other)
 		{
 			if ((object)publishAck == null || (object)other == null)
-				return !Object.Equals(publishAck, other);
+				return !Object.Equals (publishAck, other);
 
-			return !publishAck.Equals(other);
+			return !publishAck.Equals (other);
 		}
 
 		public override int GetHashCode ()
 		{
-			return this.PacketId.GetHashCode ();
+			return PacketId.GetHashCode ();
 		}
 	}
 }

--- a/src/Core/Packets/PublishComplete.cs
+++ b/src/Core/Packets/PublishComplete.cs
@@ -2,24 +2,24 @@
 {
 	internal class PublishComplete : IFlowPacket, IEquatable<PublishComplete>
 	{
-		public PublishComplete(ushort packetId)
+		public PublishComplete (ushort packetId)
 		{
-			this.PacketId = packetId;
+			PacketId = packetId;
 		}
 
 		public PacketType Type { get { return PacketType.PublishComplete; } }
 
 		public ushort PacketId { get; private set; }
 
-		public bool Equals(PublishComplete other)
+		public bool Equals (PublishComplete other)
 		{
 			if (other == null)
 				return false;
 
-			return this.PacketId == other.PacketId;
+			return PacketId == other.PacketId;
 		}
 
-		public override bool Equals(object obj)
+		public override bool Equals (object obj)
 		{
 			if (obj == null)
 				return false;
@@ -29,28 +29,28 @@
 			if (publishComplete == null)
 				return false;
 
-			return this.Equals(publishComplete);
+			return Equals (publishComplete);
 		}
 
-		public static bool operator ==(PublishComplete publishComplete, PublishComplete other)
+		public static bool operator == (PublishComplete publishComplete, PublishComplete other)
 		{
 			if ((object)publishComplete == null || (object)other == null)
-				return Object.Equals(publishComplete, other);
+				return Object.Equals (publishComplete, other);
 
-			return publishComplete.Equals(other);
+			return publishComplete.Equals (other);
 		}
 
-		public static bool operator !=(PublishComplete publishComplete, PublishComplete other)
+		public static bool operator != (PublishComplete publishComplete, PublishComplete other)
 		{
 			if ((object)publishComplete == null || (object)other == null)
-				return !Object.Equals(publishComplete, other);
+				return !Object.Equals (publishComplete, other);
 
-			return !publishComplete.Equals(other);
+			return !publishComplete.Equals (other);
 		}
 
-		public override int GetHashCode()
+		public override int GetHashCode ()
 		{
-			return this.PacketId.GetHashCode();
+			return PacketId.GetHashCode ();
 		}
 	}
 }

--- a/src/Core/Packets/PublishReceived.cs
+++ b/src/Core/Packets/PublishReceived.cs
@@ -2,24 +2,24 @@
 {
 	internal class PublishReceived : IFlowPacket, IEquatable<PublishReceived>
 	{
-		public PublishReceived(ushort packetId)
+		public PublishReceived (ushort packetId)
 		{
-			this.PacketId = packetId;
+			PacketId = packetId;
 		}
 
 		public PacketType Type { get { return PacketType.PublishReceived; } }
 
 		public ushort PacketId { get; private set; }
 
-		public bool Equals(PublishReceived other)
+		public bool Equals (PublishReceived other)
 		{
 			if (other == null)
 				return false;
 
-			return this.PacketId == other.PacketId;
+			return PacketId == other.PacketId;
 		}
 
-		public override bool Equals(object obj)
+		public override bool Equals (object obj)
 		{
 			if (obj == null)
 				return false;
@@ -29,28 +29,28 @@
 			if (publishReceived == null)
 				return false;
 
-			return this.Equals(publishReceived);
+			return Equals (publishReceived);
 		}
 
-		public static bool operator ==(PublishReceived publishReceived, PublishReceived other)
+		public static bool operator == (PublishReceived publishReceived, PublishReceived other)
 		{
 			if ((object)publishReceived == null || (object)other == null)
-				return Object.Equals(publishReceived, other);
+				return Object.Equals (publishReceived, other);
 
-			return publishReceived.Equals(other);
+			return publishReceived.Equals (other);
 		}
 
-		public static bool operator !=(PublishReceived publishReceived, PublishReceived other)
+		public static bool operator != (PublishReceived publishReceived, PublishReceived other)
 		{
 			if ((object)publishReceived == null || (object)other == null)
-				return !Object.Equals(publishReceived, other);
+				return !Object.Equals (publishReceived, other);
 
-			return !publishReceived.Equals(other);
+			return !publishReceived.Equals (other);
 		}
 
-		public override int GetHashCode()
+		public override int GetHashCode ()
 		{
-			return this.PacketId.GetHashCode();
+			return PacketId.GetHashCode ();
 		}
 	}
 }

--- a/src/Core/Packets/PublishRelease.cs
+++ b/src/Core/Packets/PublishRelease.cs
@@ -1,22 +1,22 @@
 ﻿namespace System.Net.Mqtt.Packets
 {
 	internal class PublishRelease : IFlowPacket, IEquatable<PublishRelease>
-    {
-        public PublishRelease(ushort packetId)
-        {
-            this.PacketId = packetId;
-        }
+	{
+		public PublishRelease (ushort packetId)
+		{
+			PacketId = packetId;
+		}
 
-		public PacketType Type { get { return PacketType.PublishRelease; }}
+		public PacketType Type { get { return PacketType.PublishRelease; } }
 
-        public ushort PacketId { get; private set; }
+		public ushort PacketId { get; private set; }
 
 		public bool Equals (PublishRelease other)
 		{
 			if (other == null)
 				return false;
 
-			return this.PacketId == other.PacketId;
+			return PacketId == other.PacketId;
 		}
 
 		public override bool Equals (object obj)
@@ -29,28 +29,28 @@
 			if (publishRelease == null)
 				return false;
 
-			return this.Equals (publishRelease);
+			return Equals (publishRelease);
 		}
 
 		public static bool operator == (PublishRelease publishRelease, PublishRelease other)
 		{
 			if ((object)publishRelease == null || (object)other == null)
-				return Object.Equals(publishRelease, other);
+				return Object.Equals (publishRelease, other);
 
-			return publishRelease.Equals(other);
+			return publishRelease.Equals (other);
 		}
 
 		public static bool operator != (PublishRelease publishRelease, PublishRelease other)
 		{
 			if ((object)publishRelease == null || (object)other == null)
-				return !Object.Equals(publishRelease, other);
+				return !Object.Equals (publishRelease, other);
 
-			return !publishRelease.Equals(other);
+			return !publishRelease.Equals (other);
 		}
 
 		public override int GetHashCode ()
 		{
-			return this.PacketId.GetHashCode ();
+			return PacketId.GetHashCode ();
 		}
-    }
+	}
 }

--- a/src/Core/Packets/Subscribe.cs
+++ b/src/Core/Packets/Subscribe.cs
@@ -4,26 +4,26 @@ using System.Linq;
 namespace System.Net.Mqtt.Packets
 {
 	internal class Subscribe : IFlowPacket, IEquatable<Subscribe>
-    {
-        public Subscribe(ushort packetId, params Subscription[] subscriptions)
-        {
-			this.PacketId = packetId;
-            this.Subscriptions = subscriptions;
-        }
+	{
+		public Subscribe (ushort packetId, params Subscription[] subscriptions)
+		{
+			PacketId = packetId;
+			Subscriptions = subscriptions;
+		}
 
-		public PacketType Type { get { return PacketType.Subscribe; }}
+		public PacketType Type { get { return PacketType.Subscribe; } }
 
-        public ushort PacketId { get; private set; }
+		public ushort PacketId { get; private set; }
 
-        public IEnumerable<Subscription> Subscriptions { get; private set; }
+		public IEnumerable<Subscription> Subscriptions { get; private set; }
 
 		public bool Equals (Subscribe other)
 		{
 			if (other == null)
 				return false;
 
-			return this.PacketId == other.PacketId &&
-				this.Subscriptions.SequenceEqual(other.Subscriptions);
+			return PacketId == other.PacketId &&
+				Subscriptions.SequenceEqual (other.Subscriptions);
 		}
 
 		public override bool Equals (object obj)
@@ -36,28 +36,28 @@ namespace System.Net.Mqtt.Packets
 			if (subscribe == null)
 				return false;
 
-			return this.Equals (subscribe);
+			return Equals (subscribe);
 		}
 
 		public static bool operator == (Subscribe subscribe, Subscribe other)
 		{
 			if ((object)subscribe == null || (object)other == null)
-				return Object.Equals(subscribe, other);
+				return Object.Equals (subscribe, other);
 
-			return subscribe.Equals(other);
+			return subscribe.Equals (other);
 		}
 
 		public static bool operator != (Subscribe subscribe, Subscribe other)
 		{
 			if ((object)subscribe == null || (object)other == null)
-				return !Object.Equals(subscribe, other);
+				return !Object.Equals (subscribe, other);
 
-			return !subscribe.Equals(other);
+			return !subscribe.Equals (other);
 		}
 
 		public override int GetHashCode ()
 		{
-			return this.PacketId.GetHashCode () + this.Subscriptions.GetHashCode ();
+			return PacketId.GetHashCode () + Subscriptions.GetHashCode ();
 		}
 	}
 }

--- a/src/Core/Packets/SubscribeAck.cs
+++ b/src/Core/Packets/SubscribeAck.cs
@@ -4,26 +4,26 @@ using System.Linq;
 namespace System.Net.Mqtt.Packets
 {
 	internal class SubscribeAck : IPacket, IEquatable<SubscribeAck>
-    {
-        public SubscribeAck(ushort packetId, params SubscribeReturnCode[] returnCodes)
-        {
-			this.PacketId = packetId;
-			this.ReturnCodes = returnCodes;
-        }
+	{
+		public SubscribeAck (ushort packetId, params SubscribeReturnCode[] returnCodes)
+		{
+			PacketId = packetId;
+			ReturnCodes = returnCodes;
+		}
 
-		public PacketType Type { get { return PacketType.SubscribeAck; }}
+		public PacketType Type { get { return PacketType.SubscribeAck; } }
 
-        public ushort PacketId { get; private set; }
+		public ushort PacketId { get; private set; }
 
-        public IEnumerable<SubscribeReturnCode> ReturnCodes { get; private set; }
+		public IEnumerable<SubscribeReturnCode> ReturnCodes { get; private set; }
 
 		public bool Equals (SubscribeAck other)
 		{
 			if (other == null)
 				return false;
 
-			return this.PacketId == other.PacketId &&
-				this.ReturnCodes.SequenceEqual(other.ReturnCodes);
+			return PacketId == other.PacketId &&
+				ReturnCodes.SequenceEqual (other.ReturnCodes);
 		}
 
 		public override bool Equals (object obj)
@@ -36,28 +36,28 @@ namespace System.Net.Mqtt.Packets
 			if (subscribeAck == null)
 				return false;
 
-			return this.Equals (subscribeAck);
+			return Equals (subscribeAck);
 		}
 
 		public static bool operator == (SubscribeAck subscribeAck, SubscribeAck other)
 		{
 			if ((object)subscribeAck == null || (object)other == null)
-				return Object.Equals(subscribeAck, other);
+				return Object.Equals (subscribeAck, other);
 
-			return subscribeAck.Equals(other);
+			return subscribeAck.Equals (other);
 		}
 
 		public static bool operator != (SubscribeAck subscribeAck, SubscribeAck other)
 		{
 			if ((object)subscribeAck == null || (object)other == null)
-				return !Object.Equals(subscribeAck, other);
+				return !Object.Equals (subscribeAck, other);
 
-			return !subscribeAck.Equals(other);
+			return !subscribeAck.Equals (other);
 		}
 
 		public override int GetHashCode ()
 		{
-			return this.PacketId.GetHashCode () + this.ReturnCodes.GetHashCode ();
+			return PacketId.GetHashCode () + ReturnCodes.GetHashCode ();
 		}
 	}
 }

--- a/src/Core/Packets/Subscription.cs
+++ b/src/Core/Packets/Subscription.cs
@@ -1,24 +1,24 @@
 ﻿namespace System.Net.Mqtt.Packets
 {
 	internal class Subscription : IEquatable<Subscription>
-    {
-        public Subscription(string topicFilter, QualityOfService requestedQos)
-        {
-            this.TopicFilter = topicFilter;
-            this.MaximumQualityOfService = requestedQos;
-        }
+	{
+		public Subscription (string topicFilter, QualityOfService requestedQos)
+		{
+			TopicFilter = topicFilter;
+			MaximumQualityOfService = requestedQos;
+		}
 
-        public string TopicFilter { get; set; }
+		public string TopicFilter { get; set; }
 
-        public QualityOfService MaximumQualityOfService { get; set; }
+		public QualityOfService MaximumQualityOfService { get; set; }
 
 		public bool Equals (Subscription other)
 		{
 			if (other == null)
 				return false;
 
-			return this.TopicFilter == other.TopicFilter &&
-				this.MaximumQualityOfService == other.MaximumQualityOfService;
+			return TopicFilter == other.TopicFilter &&
+				MaximumQualityOfService == other.MaximumQualityOfService;
 		}
 
 		public override bool Equals (object obj)
@@ -31,28 +31,28 @@
 			if (subscription == null)
 				return false;
 
-			return this.Equals (subscription);
+			return Equals (subscription);
 		}
 
 		public static bool operator == (Subscription subscription, Subscription other)
 		{
 			if ((object)subscription == null || (object)other == null)
-				return Object.Equals(subscription, other);
+				return Object.Equals (subscription, other);
 
-			return subscription.Equals(other);
+			return subscription.Equals (other);
 		}
 
 		public static bool operator != (Subscription subscription, Subscription other)
 		{
 			if ((object)subscription == null || (object)other == null)
-				return !Object.Equals(subscription, other);
+				return !Object.Equals (subscription, other);
 
-			return !subscription.Equals(other);
+			return !subscription.Equals (other);
 		}
 
 		public override int GetHashCode ()
 		{
-			return this.TopicFilter.GetHashCode () + this.MaximumQualityOfService.GetHashCode ();
+			return TopicFilter.GetHashCode () + MaximumQualityOfService.GetHashCode ();
 		}
 	}
 }

--- a/src/Core/Packets/Unsubscribe.cs
+++ b/src/Core/Packets/Unsubscribe.cs
@@ -5,10 +5,10 @@ namespace System.Net.Mqtt.Packets
 {
 	internal class Unsubscribe : IPacket, IEquatable<Unsubscribe>
 	{
-		public Unsubscribe(ushort packetId, params string[] topics)
+		public Unsubscribe (ushort packetId, params string[] topics)
 		{
-			this.PacketId = packetId;
-			this.Topics = topics;
+			PacketId = packetId;
+			Topics = topics;
 		}
 
 		public PacketType Type { get { return PacketType.Unsubscribe; } }
@@ -17,16 +17,16 @@ namespace System.Net.Mqtt.Packets
 
 		public IEnumerable<string> Topics { get; private set; }
 
-		public bool Equals(Unsubscribe other)
+		public bool Equals (Unsubscribe other)
 		{
 			if (other == null)
 				return false;
 
-			return this.PacketId == other.PacketId &&
-				this.Topics.SequenceEqual(other.Topics);
+			return PacketId == other.PacketId &&
+				Topics.SequenceEqual (other.Topics);
 		}
 
-		public override bool Equals(object obj)
+		public override bool Equals (object obj)
 		{
 			if (obj == null)
 				return false;
@@ -36,28 +36,28 @@ namespace System.Net.Mqtt.Packets
 			if (unsubscribe == null)
 				return false;
 
-			return this.Equals(unsubscribe);
+			return Equals (unsubscribe);
 		}
 
-		public static bool operator ==(Unsubscribe unsubscribe, Unsubscribe other)
+		public static bool operator == (Unsubscribe unsubscribe, Unsubscribe other)
 		{
 			if ((object)unsubscribe == null || (object)other == null)
-				return Object.Equals(unsubscribe, other);
+				return Object.Equals (unsubscribe, other);
 
-			return unsubscribe.Equals(other);
+			return unsubscribe.Equals (other);
 		}
 
-		public static bool operator !=(Unsubscribe unsubscribe, Unsubscribe other)
+		public static bool operator != (Unsubscribe unsubscribe, Unsubscribe other)
 		{
 			if ((object)unsubscribe == null || (object)other == null)
-				return !Object.Equals(unsubscribe, other);
+				return !Object.Equals (unsubscribe, other);
 
-			return !unsubscribe.Equals(other);
+			return !unsubscribe.Equals (other);
 		}
 
-		public override int GetHashCode()
+		public override int GetHashCode ()
 		{
-			return this.PacketId.GetHashCode() + this.Topics.GetHashCode();
+			return PacketId.GetHashCode () + Topics.GetHashCode ();
 		}
 	}
 }

--- a/src/Core/Packets/UnsubscribeAck.cs
+++ b/src/Core/Packets/UnsubscribeAck.cs
@@ -1,22 +1,22 @@
 ﻿namespace System.Net.Mqtt.Packets
 {
 	internal class UnsubscribeAck : IFlowPacket, IEquatable<UnsubscribeAck>
-    {
-        public UnsubscribeAck(ushort packetId)
-        {
-            this.PacketId = packetId;
-        }
+	{
+		public UnsubscribeAck (ushort packetId)
+		{
+			PacketId = packetId;
+		}
 
-		public PacketType Type { get { return PacketType.UnsubscribeAck; }}
+		public PacketType Type { get { return PacketType.UnsubscribeAck; } }
 
-        public ushort PacketId { get; private set; }
+		public ushort PacketId { get; private set; }
 
 		public bool Equals (UnsubscribeAck other)
 		{
 			if (other == null)
 				return false;
 
-			return this.PacketId == other.PacketId;
+			return PacketId == other.PacketId;
 		}
 
 		public override bool Equals (object obj)
@@ -29,28 +29,28 @@
 			if (unsubscribeAck == null)
 				return false;
 
-			return this.Equals (unsubscribeAck);
+			return Equals (unsubscribeAck);
 		}
 
 		public static bool operator == (UnsubscribeAck unsubscribeAck, UnsubscribeAck other)
 		{
 			if ((object)unsubscribeAck == null || (object)other == null)
-				return Object.Equals(unsubscribeAck, other);
+				return Object.Equals (unsubscribeAck, other);
 
-			return unsubscribeAck.Equals(other);
+			return unsubscribeAck.Equals (other);
 		}
 
 		public static bool operator != (UnsubscribeAck unsubscribeAck, UnsubscribeAck other)
 		{
 			if ((object)unsubscribeAck == null || (object)other == null)
-				return !Object.Equals(unsubscribeAck, other);
+				return !Object.Equals (unsubscribeAck, other);
 
-			return !unsubscribeAck.Equals(other);
+			return !unsubscribeAck.Equals (other);
 		}
 
 		public override int GetHashCode ()
 		{
-			return this.PacketId.GetHashCode ();
+			return PacketId.GetHashCode ();
 		}
-    }
+	}
 }

--- a/src/Core/Packets/Will.cs
+++ b/src/Core/Packets/Will.cs
@@ -1,18 +1,18 @@
 ﻿namespace System.Net.Mqtt.Packets
 {
 	public class Will : IEquatable<Will>
-    {
-        public Will(string topic, QualityOfService qos, bool retain, string message)
-        {
-            this.Topic = topic;
-            this.QualityOfService = qos;
-            this.Retain = retain;
-			this.Message = message;
-        }
+	{
+		public Will (string topic, QualityOfService qos, bool retain, string message)
+		{
+			Topic = topic;
+			QualityOfService = qos;
+			Retain = retain;
+			Message = message;
+		}
 
-        public string Topic { get; set; }
+		public string Topic { get; set; }
 
-        public QualityOfService QualityOfService { get; set; }
+		public QualityOfService QualityOfService { get; set; }
 
 		public bool Retain { get; set; }
 
@@ -23,10 +23,10 @@
 			if (other == null)
 				return false;
 
-			return this.Topic == other.Topic &&
-				this.QualityOfService == other.QualityOfService &&
-				this.Retain == other.Retain &&
-				this.Message == other.Message;
+			return Topic == other.Topic &&
+				QualityOfService == other.QualityOfService &&
+				Retain == other.Retain &&
+				Message == other.Message;
 		}
 
 		public override bool Equals (object obj)
@@ -39,28 +39,28 @@
 			if (will == null)
 				return false;
 
-			return this.Equals (will);
+			return Equals (will);
 		}
 
 		public static bool operator == (Will will, Will other)
 		{
 			if ((object)will == null || (object)other == null)
-				return Object.Equals(will, other);
+				return Object.Equals (will, other);
 
-			return will.Equals(other);
+			return will.Equals (other);
 		}
 
 		public static bool operator != (Will will, Will other)
 		{
 			if ((object)will == null || (object)other == null)
-				return !Object.Equals(will, other);
+				return !Object.Equals (will, other);
 
-			return !will.Equals(other);
+			return !will.Equals (other);
 		}
 
 		public override int GetHashCode ()
 		{
-			return this.Topic.GetHashCode () + this.Message.GetHashCode ();
+			return Topic.GetHashCode () + Message.GetHashCode ();
 		}
 	}
 }

--- a/src/Core/Protocol.cs
+++ b/src/Core/Protocol.cs
@@ -26,9 +26,9 @@
 
 		public static ProtocolEncoding Encoding { get; private set; }
 
-		static Protocol()
+		static Protocol ()
 		{
-			Encoding = new ProtocolEncoding();
+			Encoding = new ProtocolEncoding ();
 		}
 	}
 }

--- a/src/Core/ProtocolConfiguration.cs
+++ b/src/Core/ProtocolConfiguration.cs
@@ -6,15 +6,15 @@ namespace System.Net.Mqtt
 	{
 		public ProtocolConfiguration ()
 		{
-			this.Port = Protocol.DefaultNonSecurePort;
+			Port = Protocol.DefaultNonSecurePort;
 			// The default receive buffer size of TcpClient according to
 			// http://msdn.microsoft.com/en-us/library/system.net.sockets.tcpclient.receivebuffersize.aspx
 			// is 8192 bytes
-			this.BufferSize = 8192;
-			this.MaximumQualityOfService = QualityOfService.AtMostOnce;
-			this.KeepAliveSecs = 0;
-			this.WaitingTimeoutSecs = 5;
-			this.AllowWildcardsInTopicFilters = true;
+			BufferSize = 8192;
+			MaximumQualityOfService = QualityOfService.AtMostOnce;
+			KeepAliveSecs = 0;
+			WaitingTimeoutSecs = 5;
+			AllowWildcardsInTopicFilters = true;
 		}
 
 		public int Port { get; set; }

--- a/src/Core/ProtocolEncoding.cs
+++ b/src/Core/ProtocolEncoding.cs
@@ -16,8 +16,8 @@ namespace System.Net.Mqtt
 			var bytes = new List<byte> ();
 			var textBytes = Encoding.UTF8.GetBytes (text);
 
-			if(textBytes.Length > Protocol.MaxIntegerLength) {
-				throw new MqttException(Properties.Resources.ProtocolEncoding_StringMaxLengthExceeded);
+			if (textBytes.Length > Protocol.MaxIntegerLength) {
+				throw new MqttException (Properties.Resources.ProtocolEncoding_StringMaxLengthExceeded);
 			}
 
 			var numberBytes = Protocol.Encoding.EncodeInteger (textBytes.Length);
@@ -26,20 +26,20 @@ namespace System.Net.Mqtt
 			bytes.Add (numberBytes[numberBytes.Length - 1]);
 			bytes.AddRange (textBytes);
 
-			return bytes.ToArray();
+			return bytes.ToArray ();
 		}
 
 		/// <exception cref="MqttException">ProtocolException</exception>
-		public byte[] EncodeInteger(int number)
+		public byte[] EncodeInteger (int number)
 		{
-			if(number > Protocol.MaxIntegerLength){
-				throw new MqttException(Properties.Resources.ProtocolEncoding_IntegerMaxValueExceeded);
+			if (number > Protocol.MaxIntegerLength) {
+				throw new MqttException (Properties.Resources.ProtocolEncoding_IntegerMaxValueExceeded);
 			}
 
-			return this.EncodeInteger ((ushort)number);
+			return EncodeInteger ((ushort)number);
 		}
 
-		public byte[] EncodeInteger(ushort number)
+		public byte[] EncodeInteger (ushort number)
 		{
 			var bytes = BitConverter.GetBytes (number);
 
@@ -50,7 +50,7 @@ namespace System.Net.Mqtt
 			return bytes;
 		}
 
-		public byte[] EncodeRemainingLength(int length)
+		public byte[] EncodeRemainingLength (int length)
 		{
 			var bytes = new List<byte> ();
 			var encoded = default(int);
@@ -66,11 +66,11 @@ namespace System.Net.Mqtt
 				bytes.Add (Convert.ToByte (encoded));
 			} while (length > 0);
 
-			return bytes.ToArray();
+			return bytes.ToArray ();
 		}
 
 		/// <exception cref="MqttException">ProtocolException</exception>
-		public int DecodeRemainingLength(byte[] packet, out int arrayLength)
+		public int DecodeRemainingLength (byte[] packet, out int arrayLength)
 		{
 			var multiplier = 1;
 			var value = 0;
@@ -85,7 +85,7 @@ namespace System.Net.Mqtt
 
 				if (multiplier > 128 * 128 * 128 * 128 || index > 4)
 					throw new MqttException (Properties.Resources.ProtocolEncoding_MalformedRemainingLength);
-			} while((encodedByte & 128) != 0);
+			} while ((encodedByte & 128) != 0);
 
 			arrayLength = index;
 

--- a/src/Core/StoppedEventArgs.cs
+++ b/src/Core/StoppedEventArgs.cs
@@ -11,8 +11,8 @@
 	{
 		public ClosedEventArgs (ClosedReason reason, string message = null)
 		{
-			this.Reason = reason;
-			this.Message = message;
+			Reason = reason;
+			Message = message;
 		}
 
 		public ClosedReason Reason { get; private set; }

--- a/src/Core/Storage/ClientSession.cs
+++ b/src/Core/Storage/ClientSession.cs
@@ -6,9 +6,9 @@ namespace System.Net.Mqtt.Storage
 	{
 		public ClientSession ()
 		{
-			this.Subscriptions = new List<ClientSubscription> ();
-			this.PendingMessages = new List<PendingMessage> ();
-			this.PendingAcknowledgements = new List<PendingAcknowledgement> ();
+			Subscriptions = new List<ClientSubscription> ();
+			PendingMessages = new List<PendingMessage> ();
+			PendingAcknowledgements = new List<PendingAcknowledgement> ();
 		}
 
 		public string ClientId { get; set; }
@@ -22,4 +22,3 @@ namespace System.Net.Mqtt.Storage
 		public List<PendingAcknowledgement> PendingAcknowledgements { get; set; }
 	}
 }
- 

--- a/src/Core/Storage/IRepository.cs
+++ b/src/Core/Storage/IRepository.cs
@@ -5,32 +5,32 @@ namespace System.Net.Mqtt.Storage
 {
 	internal interface IRepository<T>
 		 where T : StorageObject
-    {
+	{
 		/// <exception cref="RepositoryException">RepositoryException</exception>
-        IEnumerable<T> GetAll(Expression<Func<T, bool>> predicate = null);
+		IEnumerable<T> GetAll (Expression<Func<T, bool>> predicate = null);
 
 		/// <exception cref="RepositoryException">RepositoryException</exception>
 		T Get (string id);
 
 		/// <exception cref="RepositoryException">RepositoryException</exception>
-        T Get(Expression<Func<T, bool>> predicate);
+		T Get (Expression<Func<T, bool>> predicate);
 
 		/// <exception cref="RepositoryException">RepositoryException</exception>
-        bool Exist(string id);
+		bool Exist (string id);
 
 		/// <exception cref="RepositoryException">RepositoryException</exception>
-        bool Exist(Expression<Func<T, bool>> predicate);
+		bool Exist (Expression<Func<T, bool>> predicate);
 
 		/// <exception cref="RepositoryException">RepositoryException</exception>
-        void Create(T element);
+		void Create (T element);
 
 		/// <exception cref="RepositoryException">RepositoryException</exception>
-        void Update(T element);
+		void Update (T element);
 
 		/// <exception cref="RepositoryException">RepositoryException</exception>
-        void Delete(T element);
+		void Delete (T element);
 
 		/// <exception cref="RepositoryException">RepositoryException</exception>
 		void Delete (Expression<Func<T, bool>> predicate);
-    }
+	}
 }

--- a/src/Core/Storage/InMemoryRepository.cs
+++ b/src/Core/Storage/InMemoryRepository.cs
@@ -7,86 +7,85 @@ namespace System.Net.Mqtt.Storage
 {
 	internal class InMemoryRepository<T> : IRepository<T>
 		where T : StorageObject
-    {
-        readonly ConcurrentDictionary<string, T> elements;
+	{
+		readonly ConcurrentDictionary<string, T> elements;
 
-		public InMemoryRepository()
+		public InMemoryRepository ()
 		{
-			this.elements = new ConcurrentDictionary<string, T>();
+			elements = new ConcurrentDictionary<string, T> ();
 		}
 
 		/// <exception cref="RepositoryException">RepositoryException</exception>
-        public IEnumerable<T> GetAll(Expression<Func<T, bool>> predicate = null)
-        {
-            var result = elements.Select(x => x.Value);
+		public IEnumerable<T> GetAll (Expression<Func<T, bool>> predicate = null)
+		{
+			var result = elements.Select(x => x.Value);
 
-            if (predicate != null)
-            {
-                result = result.Where(predicate.Compile());
-            }
+			if (predicate != null) {
+				result = result.Where (predicate.Compile ());
+			}
 
 			return result;
-        }
+		}
 
 		/// <exception cref="RepositoryException">RepositoryException</exception>
-        public T Get(string id)
-        {
+		public T Get (string id)
+		{
 			var element = default (T);
 
 			elements.TryGetValue (id, out element);
 
 			return element;
-        }
+		}
 
 		/// <exception cref="RepositoryException">RepositoryException</exception>
-        public T Get(Expression<Func<T, bool>> predicate)
-        {
-			return this.GetAll().FirstOrDefault (predicate.Compile ());
-        }
+		public T Get (Expression<Func<T, bool>> predicate)
+		{
+			return GetAll ().FirstOrDefault (predicate.Compile ());
+		}
 
 		/// <exception cref="RepositoryException">RepositoryException</exception>
-        public bool Exist(string id)
-        {
-			return this.Get (id) != default (T);
-        }
+		public bool Exist (string id)
+		{
+			return Get (id) != default (T);
+		}
 
 		/// <exception cref="RepositoryException">RepositoryException</exception>
-        public bool Exist(Expression<Func<T, bool>> predicate)
-        {
-			return this.Get (predicate) != default (T);
-        }
+		public bool Exist (Expression<Func<T, bool>> predicate)
+		{
+			return Get (predicate) != default (T);
+		}
 
 		/// <exception cref="RepositoryException">RepositoryException</exception>
-        public void Create(T element)
-        {
+		public void Create (T element)
+		{
 			elements.TryAdd (element.Id, element);
-        }
+		}
 
 		/// <exception cref="RepositoryException">RepositoryException</exception>
-        public void Update(T element)
-        {
-            this.Delete(element);
-            this.Create(element);
-        }
+		public void Update (T element)
+		{
+			Delete (element);
+			Create (element);
+		}
 
 		/// <exception cref="RepositoryException">RepositoryException</exception>
-        public void Delete(T element)
-        {
+		public void Delete (T element)
+		{
 			var removedElement = default(T);
 
 			elements.TryRemove (element.Id, out removedElement);
-        }
+		}
 
 		/// <exception cref="RepositoryException">RepositoryException</exception>
-		public void Delete(Expression<Func<T, bool>> predicate)
-        {
-			var element = this.Get (predicate);
+		public void Delete (Expression<Func<T, bool>> predicate)
+		{
+			var element = Get (predicate);
 
 			if (element == null) {
 				return;
 			}
 
-			this.Delete (element);
-        }
-    }
+			Delete (element);
+		}
+	}
 }

--- a/src/Core/Storage/InMemoryRepositoryProvider.cs
+++ b/src/Core/Storage/InMemoryRepositoryProvider.cs
@@ -9,19 +9,19 @@ namespace System.Net.Mqtt.Storage
 
 		public InMemoryRepositoryProvider ()
 		{
-			this.repositories = new Dictionary<Type, object> ();
+			repositories = new Dictionary<Type, object> ();
 		}
 
-		public IRepository<T> GetRepository<T> () 
+		public IRepository<T> GetRepository<T> ()
 			where T : StorageObject
 		{
-			if (this.repositories.Any (r => r.Key == typeof (T))) {
-				return this.repositories.FirstOrDefault (r => r.Key == typeof (T)).Value as IRepository<T>;
+			if (repositories.Any (r => r.Key == typeof (T))) {
+				return repositories.FirstOrDefault (r => r.Key == typeof (T)).Value as IRepository<T>;
 			}
 
 			var repository = new InMemoryRepository<T> ();
 
-			this.repositories.Add (typeof (T), repository);
+			repositories.Add (typeof (T), repository);
 
 			return repository;
 		}

--- a/src/Core/Storage/StorageExtensions.cs
+++ b/src/Core/Storage/StorageExtensions.cs
@@ -9,66 +9,66 @@ namespace System.Net.Mqtt.Storage
 		static readonly object pendingMessagesLock = new object ();
 		static readonly object pendingAcksLock = new object ();
 
-		public static IEnumerable<ClientSubscription> GetSubscriptions(this ClientSession session)
+		public static IEnumerable<ClientSubscription> GetSubscriptions (this ClientSession session)
 		{
 			lock (subscriptionsLock) {
 				return session.Subscriptions.ToList ();
 			}
 		}
 
-		public static void AddSubscription(this ClientSession session, ClientSubscription subscription)
+		public static void AddSubscription (this ClientSession session, ClientSubscription subscription)
 		{
 			lock (subscriptionsLock) {
-				session.Subscriptions.Add(subscription);
+				session.Subscriptions.Add (subscription);
 			}
 		}
 
-		public static void RemoveSubscription(this ClientSession session, ClientSubscription subscription)
+		public static void RemoveSubscription (this ClientSession session, ClientSubscription subscription)
 		{
-			lock (subscriptionsLock) { 
-				session.Subscriptions.Remove(subscription);
+			lock (subscriptionsLock) {
+				session.Subscriptions.Remove (subscription);
 			}
 		}
 
-		public static IEnumerable<PendingMessage> GetPendingMessages(this ClientSession session)
+		public static IEnumerable<PendingMessage> GetPendingMessages (this ClientSession session)
 		{
 			lock (pendingMessagesLock) {
 				return session.PendingMessages.ToList ();
 			}
 		}
 
-		public static void AddPendingMessage(this ClientSession session, PendingMessage pending)
+		public static void AddPendingMessage (this ClientSession session, PendingMessage pending)
 		{
 			lock (pendingMessagesLock) {
-				session.PendingMessages.Add(pending);
+				session.PendingMessages.Add (pending);
 			}
 		}
 
-		public static void RemovePendingMessage(this ClientSession session, PendingMessage pending)
+		public static void RemovePendingMessage (this ClientSession session, PendingMessage pending)
 		{
 			lock (pendingMessagesLock) {
-				session.PendingMessages.Remove(pending);
+				session.PendingMessages.Remove (pending);
 			}
 		}
 
-		public static IEnumerable<PendingAcknowledgement> GetPendingAcknowledgements(this ClientSession session)
+		public static IEnumerable<PendingAcknowledgement> GetPendingAcknowledgements (this ClientSession session)
 		{
 			lock (pendingAcksLock) {
 				return session.PendingAcknowledgements.ToList ();
 			}
 		}
 
-		public static void AddPendingAcknowledgement(this ClientSession session, PendingAcknowledgement pending)
+		public static void AddPendingAcknowledgement (this ClientSession session, PendingAcknowledgement pending)
 		{
 			lock (pendingAcksLock) {
-				session.PendingAcknowledgements.Add(pending);
+				session.PendingAcknowledgements.Add (pending);
 			}
 		}
 
-		public static void RemovePendingAcknowledgement(this ClientSession session, PendingAcknowledgement pending)
+		public static void RemovePendingAcknowledgement (this ClientSession session, PendingAcknowledgement pending)
 		{
 			lock (pendingAcksLock) {
-				session.PendingAcknowledgements.Remove(pending);
+				session.PendingAcknowledgements.Remove (pending);
 			}
 		}
 	}

--- a/src/Core/Storage/StorageObject.cs
+++ b/src/Core/Storage/StorageObject.cs
@@ -4,7 +4,7 @@
 	{
 		public StorageObject ()
 		{
-			this.Id = Guid.NewGuid ().ToString ();
+			Id = Guid.NewGuid ().ToString ();
 		}
 
 		public string Id { get; private set; }

--- a/src/Core/TaskRunner.cs
+++ b/src/Core/TaskRunner.cs
@@ -10,67 +10,68 @@ namespace System.Net.Mqtt
 
 		private TaskRunner (string name = null)
 		{
-			this.taskFactory = new TaskFactory(CancellationToken.None, 
-				TaskCreationOptions.DenyChildAttach, 
-				TaskContinuationOptions.None, 
-				new SingleThreadScheduler(name));
+			taskFactory = new TaskFactory (CancellationToken.None,
+				TaskCreationOptions.DenyChildAttach,
+				TaskContinuationOptions.None,
+				new SingleThreadScheduler (name));
 		}
 
-		public static TaskRunner Get(string name = null)
+		public static TaskRunner Get (string name = null)
 		{
 			return new TaskRunner (name);
 		}
 
-		public Task Run(Func<Task> func)
+		public Task Run (Func<Task> func)
 		{
-			if (this.disposed) {
-				throw new ObjectDisposedException (this.GetType ().FullName);
+			if (disposed) {
+				throw new ObjectDisposedException (GetType ().FullName);
 			}
 
-			return taskFactory.StartNew(func).Unwrap();
+			return taskFactory.StartNew (func).Unwrap ();
 		}
 
-		public Task<T> Run<T>(Func<Task<T>> func)
+		public Task<T> Run<T> (Func<Task<T>> func)
 		{
-			if (this.disposed) {
-				throw new ObjectDisposedException (this.GetType ().FullName);
+			if (disposed) {
+				throw new ObjectDisposedException (GetType ().FullName);
 			}
 
-			return taskFactory.StartNew(func).Unwrap();
+			return taskFactory.StartNew (func).Unwrap ();
 		}
 
-		public Task Run(Action action)
+		public Task Run (Action action)
 		{
-			if (this.disposed) {
-				throw new ObjectDisposedException (this.GetType ().FullName);
+			if (disposed) {
+				throw new ObjectDisposedException (GetType ().FullName);
 			}
 
-			return taskFactory.StartNew(action);
+			return taskFactory.StartNew (action);
 		}
 
-		public Task<T> Run<T>(Func<T> func)
+		public Task<T> Run<T> (Func<T> func)
 		{
-			if (this.disposed) {
-				throw new ObjectDisposedException (this.GetType ().FullName);
+			if (disposed) {
+				throw new ObjectDisposedException (GetType ().FullName);
 			}
 
-			return taskFactory.StartNew(func);
+			return taskFactory.StartNew (func);
 		}
 
-		public void Dispose()
+		public void Dispose ()
 		{
-			Dispose(disposing: true);
-			GC.SuppressFinalize(this);
+			Dispose (disposing: true);
+			GC.SuppressFinalize (this);
 		}
 
-		protected virtual void Dispose(bool disposing)
+		protected virtual void Dispose (bool disposing)
 		{
-			if (this.disposed)
+			if (disposed)
 				return;
 
 			if (disposing) {
-				(this.taskFactory.Scheduler as IDisposable)?.Dispose();
-				this.taskFactory = null;
+				(taskFactory.Scheduler as IDisposable)?.Dispose ();
+				taskFactory = null;
+				disposed = true;
 			}
 		}
 	}

--- a/src/Core/TcpChannelFactory.cs
+++ b/src/Core/TcpChannelFactory.cs
@@ -23,16 +23,16 @@ namespace System.Net.Mqtt
 			var tcpClient = new TcpClient ();
 
 			try {
-				tcpClient.Connect (this.hostAddress, this.configuration.Port);
+				tcpClient.Connect (hostAddress, configuration.Port);
 			} catch (SocketException socketEx) {
-				var message = string.Format(Properties.Resources.TcpChannelFactory_TcpClient_Failed, this.hostAddress, configuration.Port);
+				var message = string.Format(Properties.Resources.TcpChannelFactory_TcpClient_Failed, hostAddress, configuration.Port);
 
 				tracer.Error (socketEx, message);
 
-				throw new MqttException(message, socketEx);
+				throw new MqttException (message, socketEx);
 			}
 
-			return new TcpChannel(tcpClient, new PacketBuffer(), this.configuration);
+			return new TcpChannel (tcpClient, new PacketBuffer (), configuration);
 		}
 	}
 }

--- a/src/Core/TopicEvaluator.cs
+++ b/src/Core/TopicEvaluator.cs
@@ -14,7 +14,7 @@ namespace System.Net.Mqtt
 
 		public bool IsValidTopicFilter (string topicFilter)
 		{
-			if (!this.configuration.AllowWildcardsInTopicFilters) {
+			if (!configuration.AllowWildcardsInTopicFilters) {
 				if (topicFilter.Contains (Protocol.SingleLevelTopicWildcard) ||
 					topicFilter.Contains (Protocol.MultiLevelTopicWildcard))
 					return false;
@@ -29,7 +29,7 @@ namespace System.Net.Mqtt
 
 			var topicFilterParts = topicFilter.Split ('/');
 
-			if(topicFilterParts.Count(s => s == "#") > 1)
+			if (topicFilterParts.Count (s => s == "#") > 1)
 				return false;
 
 			if (topicFilterParts.Any (s => s.Length > 1 && s.Contains ("#")))
@@ -38,7 +38,7 @@ namespace System.Net.Mqtt
 			if (topicFilterParts.Any (s => s.Length > 1 && s.Contains ("+")))
 				return false;
 
-			if(topicFilterParts.Any(s => s == "#") && topicFilter.IndexOf("#") < topicFilter.Length - 1)
+			if (topicFilterParts.Any (s => s == "#") && topicFilter.IndexOf ("#") < topicFilter.Length - 1)
 				return false;
 
 			return true;
@@ -55,13 +55,13 @@ namespace System.Net.Mqtt
 		/// <exception cref="MqttException">ProtocolException</exception>
 		public bool Matches (string topicName, string topicFilter)
 		{
-			if (!this.IsValidTopicName (topicName)) { 
+			if (!IsValidTopicName (topicName)) {
 				var message = string.Format(Properties.Resources.TopicEvaluator_InvalidTopicName, topicName);
 
 				throw new MqttException (message);
 			}
 
-			if (!this.IsValidTopicFilter (topicFilter)) { 
+			if (!IsValidTopicFilter (topicFilter)) {
 				var message = string.Format(Properties.Resources.TopicEvaluator_InvalidTopicFilter, topicFilter);
 
 				throw new MqttException (message);
@@ -76,7 +76,7 @@ namespace System.Net.Mqtt
 			if (topicFilterParts.Length - topicNameParts.Length > 1)
 				return false;
 
-			if (topicFilterParts.Length - topicNameParts.Length == 1 && topicFilterParts[topicFilterParts.Length -1] != "#")
+			if (topicFilterParts.Length - topicNameParts.Length == 1 && topicFilterParts[topicFilterParts.Length - 1] != "#")
 				return false;
 
 			if ((topicFilterParts[0] == "#" || topicFilterParts[0] == "+") && topicNameParts[0].StartsWith ("$"))

--- a/src/Core/Tracer.cs
+++ b/src/Core/Tracer.cs
@@ -4,7 +4,7 @@ namespace System.Net.Mqtt.Diagnostics
 {
 	static partial class Tracer
 	{
-		static Tracer()
+		static Tracer ()
 		{
 			Initialize (new TracerManager ());
 		}
@@ -14,7 +14,7 @@ namespace System.Net.Mqtt.Diagnostics
 			get { return manager; }
 		}
 
-		public static ITracerManager SetManager(ITracerManager manager)
+		public static ITracerManager SetManager (ITracerManager manager)
 		{
 			Initialize (manager);
 
@@ -44,8 +44,11 @@ namespace System.Net.Mqtt.Diagnostics
 	partial interface ITracerManager
 	{
 		void SetTracingLevel (string sourceName, SourceLevels level);
+
 		void AddListener (string sourceName, TraceListener listener);
+
 		void RemoveListener (string sourceName, TraceListener listener);
+
 		void RemoveListener (string sourceName, string listenerName);
 	}
 }

--- a/src/IntegrationTests/AuthenticationSpec.cs
+++ b/src/IntegrationTests/AuthenticationSpec.cs
@@ -15,7 +15,7 @@ namespace IntegrationTests
 
 		public AuthenticationSpec ()
 		{
-			this.server = this.GetServer (new TestAuthenticationProvider(expectedUsername: "foo", expectedPassword: "foo123"));
+			server = GetServer (new TestAuthenticationProvider(expectedUsername: "foo", expectedPassword: "foo123"));
 		}
 
 		[Fact]
@@ -23,9 +23,9 @@ namespace IntegrationTests
 		{
 			var username = "foo";
 			var password = "foo123456";
-			var client = this.GetClient ();
+			var client = GetClient ();
 
-			var aggregateEx = Assert.Throws<AggregateException>(() => client.ConnectAsync (new ClientCredentials (this.GetClientId (), username, password)).Wait());
+			var aggregateEx = Assert.Throws<AggregateException>(() => client.ConnectAsync (new ClientCredentials (GetClientId (), username, password)).Wait());
 
 			Assert.NotNull (aggregateEx.InnerException);
 			Assert.True (aggregateEx.InnerException is ClientException);
@@ -39,9 +39,9 @@ namespace IntegrationTests
 		{
 			var username = "foo";
 			var password = "foo123";
-			var client = this.GetClient ();
+			var client = GetClient ();
 
-			await client.ConnectAsync (new ClientCredentials (this.GetClientId (), username, password));
+			await client.ConnectAsync (new ClientCredentials (GetClientId (), username, password));
 
 			Assert.True(client.IsConnected);
 			Assert.False(string.IsNullOrEmpty(client.Id));
@@ -49,8 +49,8 @@ namespace IntegrationTests
 
 		public void Dispose ()
 		{
-			if (this.server != null) {
-				this.server.Stop ();
+			if (server != null) {
+				server.Stop ();
 			}
 		}
 	}

--- a/src/IntegrationTests/ConnectionSpec.cs
+++ b/src/IntegrationTests/ConnectionSpec.cs
@@ -21,15 +21,15 @@ namespace IntegrationTests
 
 		public ConnectionSpec ()
 		{
-			this.server = this.GetServer ();
+			server = GetServer ();
 		}
 
 		[Fact]
 		public void when_stopping_server_then_it_is_not_reachable()
 		{
-			this.server.Stop ();
+			server.Stop ();
 
-			var ex = Assert.Throws<ClientException>(() => this.GetClient ());
+			var ex = Assert.Throws<ClientException>(() => GetClient ());
 
 			Assert.NotNull (ex);
 			Assert.NotNull (ex.InnerException);
@@ -39,11 +39,11 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_connect_clients_and_one_client_drops_connection_then_other_client_survives()
 		{
-			var fooClient = this.GetClient ();
-			var barClient = this.GetClient ();
+			var fooClient = GetClient ();
+			var barClient = GetClient ();
 
-			await fooClient.ConnectAsync (new ClientCredentials (this.GetClientId ()));
-			await barClient.ConnectAsync (new ClientCredentials (this.GetClientId ()));
+			await fooClient.ConnectAsync (new ClientCredentials (GetClientId ()));
+			await barClient.ConnectAsync (new ClientCredentials (GetClientId ()));
 
 			var exceptionThrown = false;
 
@@ -75,14 +75,14 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_connect_clients_then_succeeds()
 		{
-			var count = this.GetTestLoad ();
+			var count = GetTestLoad ();
 			var clients = new List<IClient> ();
 			var tasks = new List<Task> ();
 
 			for (var i = 1; i <= count; i++) {
-				var client = this.GetClient ();
+				var client = GetClient ();
 
-				tasks.Add (client.ConnectAsync (new ClientCredentials (this.GetClientId ())));
+				tasks.Add (client.ConnectAsync (new ClientCredentials (GetClientId ())));
 				clients.Add (client);
 			}
 
@@ -100,14 +100,14 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_disconnect_clients_then_succeeds()
 		{
-			var count = this.GetTestLoad ();
+			var count = GetTestLoad ();
 			var clients = new List<IClient> ();
 			var connectTasks = new List<Task> ();
 
 			for (var i = 1; i <= count; i++) {
-				var client = this.GetClient ();
+				var client = GetClient ();
 
-				connectTasks.Add(client.ConnectAsync (new ClientCredentials (this.GetClientId ())));
+				connectTasks.Add(client.ConnectAsync (new ClientCredentials (GetClientId ())));
 				clients.Add (client);
 			}
 
@@ -141,9 +141,9 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_disconnect_client_then_server_decrease_active_client_list()
 		{
-			var client = this.GetClient ();
+			var client = GetClient ();
 
-			await client.ConnectAsync (new ClientCredentials (this.GetClientId ()))
+			await client.ConnectAsync (new ClientCredentials (GetClientId ()))
 				.ConfigureAwait(continueOnCapturedContext: false);
 
 			var clientId = client.Id;
@@ -189,9 +189,9 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_client_disconnects_by_protocol_then_will_message_is_not_sent()
 		{
-			var client1 = this.GetClient ();
-			var client2 = this.GetClient ();
-			var client3 = this.GetClient ();
+			var client1 = GetClient ();
+			var client2 = GetClient ();
+			var client3 = GetClient ();
 
 			var topic = Guid.NewGuid ().ToString ();
 			var qos = QualityOfService.ExactlyOnce;
@@ -199,9 +199,9 @@ namespace IntegrationTests
 			var message = "Client 1 has been disconnected unexpectedly";
 			var will = new Will(topic, qos, retain, message);
 
-			await client1.ConnectAsync (new ClientCredentials (this.GetClientId ()), will);
-			await client2.ConnectAsync (new ClientCredentials (this.GetClientId ()));
-			await client3.ConnectAsync (new ClientCredentials (this.GetClientId ()));
+			await client1.ConnectAsync (new ClientCredentials (GetClientId ()), will);
+			await client2.ConnectAsync (new ClientCredentials (GetClientId ()));
+			await client3.ConnectAsync (new ClientCredentials (GetClientId ()));
 
 			await client2.SubscribeAsync(topic, QualityOfService.AtMostOnce);
 			await client3.SubscribeAsync(topic, QualityOfService.AtLeastOnce);
@@ -233,9 +233,9 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_client_disconnects_unexpectedly_then_will_message_is_sent()
 		{
-			var client1 = this.GetClient ();
-			var client2 = this.GetClient ();
-			var client3 = this.GetClient ();
+			var client1 = GetClient ();
+			var client2 = GetClient ();
+			var client3 = GetClient ();
 
 			var topic = Guid.NewGuid ().ToString ();
 			var qos = QualityOfService.ExactlyOnce;
@@ -243,9 +243,9 @@ namespace IntegrationTests
 			var message = "Client 1 has been disconnected unexpectedly";
 			var will = new Will(topic, qos, retain, message);
 
-			await client1.ConnectAsync (new ClientCredentials (this.GetClientId ()), will);
-			await client2.ConnectAsync (new ClientCredentials (this.GetClientId ()));
-			await client3.ConnectAsync (new ClientCredentials (this.GetClientId ()));
+			await client1.ConnectAsync (new ClientCredentials (GetClientId ()), will);
+			await client2.ConnectAsync (new ClientCredentials (GetClientId ()));
+			await client3.ConnectAsync (new ClientCredentials (GetClientId ()));
 
 			await client2.SubscribeAsync(topic, QualityOfService.AtMostOnce);
 			await client3.SubscribeAsync(topic, QualityOfService.AtLeastOnce);
@@ -282,8 +282,8 @@ namespace IntegrationTests
 
 		public void Dispose ()
 		{
-			if (this.server != null) {
-				this.server.Stop ();
+			if (server != null) {
+				server.Stop ();
 			}
 		}
 	}

--- a/src/IntegrationTests/ConnectionSpecWithKeepAlive.cs
+++ b/src/IntegrationTests/ConnectionSpecWithKeepAlive.cs
@@ -17,15 +17,15 @@ namespace IntegrationTests
 		public ConnectionSpecWithKeepAlive () 
 			: base(keepAliveSecs: 1)
 		{
-			this.server = this.GetServer ();
+			server = GetServer ();
 		}
 
 		[Fact]
 		public async Task when_keep_alive_enabled_and_client_is_disposed_then_server_refresh_active_client_list()
 		{
-			var client = this.GetClient ();
+			var client = GetClient ();
 
-			await client.ConnectAsync (new ClientCredentials (this.GetClientId ()))
+			await client.ConnectAsync (new ClientCredentials (GetClientId ()))
 				.ConfigureAwait(continueOnCapturedContext: false);
 
 			var clientId = client.Id;
@@ -57,7 +57,7 @@ namespace IntegrationTests
 
 			client.Close ();
 
-			var serverDetectedClientClosed = clientClosed.Wait (TimeSpan.FromSeconds(this.keepAliveSecs * 2));
+			var serverDetectedClientClosed = clientClosed.Wait (TimeSpan.FromSeconds(keepAliveSecs * 2));
 
 			subscription.Dispose ();
 
@@ -69,12 +69,12 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_keep_alive_enabled_and_no_packets_are_sent_then_connection_is_maintained()
 		{
-			var client = this.GetClient ();
+			var client = GetClient ();
 
-			await client.ConnectAsync (new ClientCredentials (this.GetClientId ()))
+			await client.ConnectAsync (new ClientCredentials (GetClientId ()))
 				.ConfigureAwait(continueOnCapturedContext: false);
 
-			Thread.Sleep (TimeSpan.FromSeconds(this.keepAliveSecs * 5));
+			Thread.Sleep (TimeSpan.FromSeconds(keepAliveSecs * 5));
 
 			Assert.Equal (1, server.ActiveClients.Count ());
 			Assert.True(client.IsConnected);
@@ -85,8 +85,8 @@ namespace IntegrationTests
 
 		public void Dispose ()
 		{
-			if (this.server != null) {
-				this.server.Stop ();
+			if (server != null) {
+				server.Stop ();
 			}
 		}
 	}

--- a/src/IntegrationTests/Context/ConnectedContext.cs
+++ b/src/IntegrationTests/Context/ConnectedContext.cs
@@ -13,7 +13,7 @@ namespace IntegrationTests.Context
 		{
 			var client = base.GetClient ();
 
-			client.ConnectAsync (new ClientCredentials (this.GetClientId ())).Wait ();
+			client.ConnectAsync (new ClientCredentials (GetClientId ())).Wait ();
 
 			return client;
 		}

--- a/src/IntegrationTests/Context/IntegrationContext.cs
+++ b/src/IntegrationTests/Context/IntegrationContext.cs
@@ -16,8 +16,8 @@ namespace IntegrationTests.Context
 {
 	public abstract class IntegrationContext
 	{
-		private static readonly ConcurrentBag<int> usedPorts;
-		private static Random random = new Random ();
+		static readonly ConcurrentBag<int> usedPorts;
+		static Random random = new Random ();
 
 		protected readonly ushort keepAliveSecs;
 		
@@ -39,10 +39,10 @@ namespace IntegrationTests.Context
 		protected Server GetServer(IAuthenticationProvider authenticationProvider = null)
 		{
 			try {
-				this.LoadConfiguration ();
+				LoadConfiguration ();
 
 				var initializer = new ServerInitializer (authenticationProvider);
-				var server = initializer.Initialize (this.Configuration);
+				var server = initializer.Initialize (Configuration);
 
 				server.Start ();
 
@@ -60,11 +60,11 @@ namespace IntegrationTests.Context
 		{
 			var initializer = new ClientInitializer (IPAddress.Loopback.ToString());
 
-			if (this.Configuration == null) {
-				this.LoadConfiguration ();
+			if (Configuration == null) {
+				LoadConfiguration ();
 			}
 
-			return initializer.Initialize (this.Configuration);
+			return initializer.Initialize (Configuration);
 		}
 
 		protected string GetClientId()
@@ -82,18 +82,18 @@ namespace IntegrationTests.Context
 			return testLoad;
 		}
 
-		private void LoadConfiguration()
+		void LoadConfiguration()
 		{
-			this.Configuration = new ProtocolConfiguration {
+			Configuration = new ProtocolConfiguration {
 				BufferSize = 128 * 1024,
 				Port = GetPort(),
-				KeepAliveSecs = this.keepAliveSecs,
+				KeepAliveSecs = keepAliveSecs,
 				WaitingTimeoutSecs = 2,
 				MaximumQualityOfService = QualityOfService.ExactlyOnce
 			};
 		}
 
-		private static int GetPort()
+		static int GetPort()
 		{
 			var port = random.Next (minValue: 40000, maxValue: 65535);
 

--- a/src/IntegrationTests/ExceptionSpec.cs
+++ b/src/IntegrationTests/ExceptionSpec.cs
@@ -14,7 +14,7 @@ namespace IntegrationTests
 		[Fact]
 		public void when_connecting_client_to_non_existing_server_then_fails()
 		{
-			var clientException = Assert.Throws<ClientException>(() => this.GetClient ());
+			var clientException = Assert.Throws<ClientException>(() => GetClient ());
 
 			Assert.NotNull (clientException);
 			Assert.NotNull (clientException.InnerException);
@@ -26,10 +26,10 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_server_is_closed_then_error_occurs_when_client_send_message()
 		{
-			var server = this.GetServer ();
-			var client = this.GetClient ();
+			var server = GetServer ();
+			var client = GetClient ();
 
-			await client.ConnectAsync (new ClientCredentials(this.GetClientId()))
+			await client.ConnectAsync (new ClientCredentials(GetClientId ()))
 				.ConfigureAwait(continueOnCapturedContext: false);
 
 			server.Stop ();

--- a/src/IntegrationTests/PublishingSpec.cs
+++ b/src/IntegrationTests/PublishingSpec.cs
@@ -19,19 +19,19 @@ namespace IntegrationTests
 		public PublishingSpec () 
 			: base(keepAliveSecs: 1)
 		{
-			this.server = this.GetServer ();
+			server = GetServer ();
 		}
 
 		[Fact]
 		public async Task when_publish_messages_with_qos0_then_succeeds()
 		{
-			var client = this.GetClient ();
+			var client = GetClient ();
 			var topic = Guid.NewGuid ().ToString ();
-			var count = this.GetTestLoad();
+			var count = GetTestLoad();
 			var tasks = new List<Task> ();
 
 			for (var i = 1; i <= count; i++) {
-				var testMessage = this.GetTestMessage();
+				var testMessage = GetTestMessage();
 				var message = new ApplicationMessage
 				{
 					Topic = topic,
@@ -51,13 +51,13 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_publish_messages_with_qos1_then_succeeds()
 		{
-			var client = this.GetClient ();
+			var client = GetClient ();
 			var topic = Guid.NewGuid ().ToString ();
-			var count = this.GetTestLoad();
+			var count = GetTestLoad();
 			var tasks = new List<Task> ();
 
 			for (var i = 1; i <= count; i++) {
-				var testMessage = this.GetTestMessage();
+				var testMessage = GetTestMessage();
 				var message = new ApplicationMessage
 				{
 					Topic = topic,
@@ -77,13 +77,13 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_publish_messages_with_qos2_then_succeeds()
 		{
-			var client = this.GetClient ();
+			var client = GetClient ();
 			var topic = Guid.NewGuid ().ToString ();
-			var count = this.GetTestLoad();
+			var count = GetTestLoad();
 			var tasks = new List<Task> ();
 
 			for (var i = 1; i <= count; i++) {
-				var testMessage = this.GetTestMessage();
+				var testMessage = GetTestMessage();
 				var message = new ApplicationMessage
 				{
 					Topic = topic,
@@ -103,15 +103,15 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_publish_message_to_topic_then_message_is_dispatched_to_subscribers()
 		{
-			var count = this.GetTestLoad();
+			var count = GetTestLoad();
 
 			var guid = Guid.NewGuid ().ToString ();
 			var topicFilter = guid + "/#";
 			var topic = guid;
 
-			var publisher = this.GetClient ();
-			var subscriber1 = this.GetClient ();
-			var subscriber2 = this.GetClient ();
+			var publisher = GetClient ();
+			var subscriber1 = GetClient ();
+			var subscriber2 = GetClient ();
 
 			var subscriber1Done = new ManualResetEventSlim ();
 			var subscriber2Done = new ManualResetEventSlim ();
@@ -146,7 +146,7 @@ namespace IntegrationTests
 			var tasks = new List<Task> ();
 
 			for (var i = 1; i <= count; i++) {
-				var testMessage = this.GetTestMessage();
+				var testMessage = GetTestMessage();
 				var message = new ApplicationMessage
 				{ 
 					Topic = topic,
@@ -158,7 +158,7 @@ namespace IntegrationTests
 
 			await Task.WhenAll (tasks);
 
-			var completed = WaitHandle.WaitAll (new WaitHandle[] { subscriber1Done.WaitHandle, subscriber2Done.WaitHandle }, TimeSpan.FromSeconds(this.Configuration.WaitingTimeoutSecs));
+			var completed = WaitHandle.WaitAll (new WaitHandle[] { subscriber1Done.WaitHandle, subscriber2Done.WaitHandle }, TimeSpan.FromSeconds(Configuration.WaitingTimeoutSecs));
 
 			Assert.Equal (count, subscriber1Received);
 			Assert.Equal (count, subscriber2Received);
@@ -177,10 +177,10 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_publish_message_to_topic_and_there_is_no_subscribers_then_server_notifies()
 		{
-			var count = this.GetTestLoad();
+			var count = GetTestLoad();
 
 			var topic = Guid.NewGuid ().ToString ();
-			var publisher = this.GetClient ();
+			var publisher = GetClient ();
 			var topicsNotSubscribedCount = 0;
 			var topicsNotSubscribedDone = new ManualResetEventSlim ();
 
@@ -195,7 +195,7 @@ namespace IntegrationTests
 			var tasks = new List<Task> ();
 
 			for (var i = 1; i <= count; i++) {
-				var testMessage = this.GetTestMessage();
+				var testMessage = GetTestMessage();
 				var message = new ApplicationMessage
 				{ 
 					Topic = topic,
@@ -207,7 +207,7 @@ namespace IntegrationTests
 
 			await Task.WhenAll (tasks);
 
-			var success = topicsNotSubscribedDone.Wait (TimeSpan.FromSeconds(this.keepAliveSecs * 2));
+			var success = topicsNotSubscribedDone.Wait (TimeSpan.FromSeconds(keepAliveSecs * 2));
 
 			Assert.Equal (count, topicsNotSubscribedCount);
 			Assert.True (success);
@@ -218,14 +218,14 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_publish_message_to_topic_and_expect_reponse_to_other_topic_then_succeeds()
 		{
-			var count = this.GetTestLoad();
+			var count = GetTestLoad();
 
 			var guid = Guid.NewGuid ().ToString ();
 			var requestTopic = guid;
 			var responseTopic = guid + "/response";
 
-			var publisher = this.GetClient ();
-			var subscriber = this.GetClient ();
+			var publisher = GetClient ();
+			var subscriber = GetClient ();
 
 			var subscriberDone = new ManualResetEventSlim ();
 			var subscriberReceived = 0;
@@ -239,7 +239,7 @@ namespace IntegrationTests
 				.Subscribe (async m => {
 					if (m.Topic == requestTopic) {
 						var request = Serializer.Deserialize<RequestMessage>(m.Payload);
-						var response = this.GetResponseMessage (request);
+						var response = GetResponseMessage (request);
 						var message = new ApplicationMessage {
 							Topic = responseTopic,
 							Payload = Serializer.Serialize(response)
@@ -263,7 +263,7 @@ namespace IntegrationTests
 			var tasks = new List<Task> ();
 
 			for (var i = 1; i <= count; i++) {
-				var request = this.GetRequestMessage ();
+				var request = GetRequestMessage ();
 				var message = new ApplicationMessage
 				{ 
 					Topic = requestTopic,
@@ -275,7 +275,7 @@ namespace IntegrationTests
 
 			await Task.WhenAll (tasks);
 
-			var completed = subscriberDone.Wait (TimeSpan.FromSeconds (this.Configuration.WaitingTimeoutSecs));
+			var completed = subscriberDone.Wait (TimeSpan.FromSeconds (Configuration.WaitingTimeoutSecs));
 
 			Assert.Equal (count, subscriberReceived);
 			Assert.True (completed);
@@ -292,8 +292,8 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_publish_with_qos0_and_subscribe_with_same_client_intensively_then_succeeds()
 		{
-			var client = this.GetClient ();
-			var count = this.GetTestLoad ();
+			var client = GetClient ();
+			var count = GetTestLoad ();
 			var tasks = new List<Task> ();
 
 			for (var i = 1; i <= count; i++) {
@@ -312,8 +312,8 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_publish_with_qos1_and_subscribe_with_same_client_intensively_then_succeeds()
 		{
-			var client = this.GetClient ();
-			var count = this.GetTestLoad ();
+			var client = GetClient ();
+			var count = GetTestLoad ();
 			var tasks = new List<Task> ();
 
 			for (var i = 1; i <= count; i++) {
@@ -332,8 +332,8 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_publish_with_qos2_and_subscribe_with_same_client_intensively_then_succeeds()
 		{
-			var client = this.GetClient ();
-			var count = this.GetTestLoad ();
+			var client = GetClient ();
+			var count = GetTestLoad ();
 			var tasks = new List<Task> ();
 
 			for (var i = 1; i <= count; i++) {
@@ -351,12 +351,12 @@ namespace IntegrationTests
 
 		public void Dispose ()
 		{
-			if (this.server != null) {
-				this.server.Stop ();
+			if (server != null) {
+				server.Stop ();
 			}
 		}
 
-		private TestMessage GetTestMessage()
+		TestMessage GetTestMessage()
 		{
 			return new TestMessage {
 				Name = string.Concat("Message ", Guid.NewGuid().ToString().Substring(0, 4)),
@@ -364,7 +364,7 @@ namespace IntegrationTests
 			};
 		}
 
-		private RequestMessage GetRequestMessage()
+		RequestMessage GetRequestMessage()
 		{
 			return new RequestMessage {
 				Id = Guid.NewGuid(),
@@ -374,7 +374,7 @@ namespace IntegrationTests
 			};
 		}
 
-		private ResponseMessage GetResponseMessage(RequestMessage request)
+		ResponseMessage GetResponseMessage(RequestMessage request)
 		{
 			return new ResponseMessage {
 				Name = request.Name,

--- a/src/IntegrationTests/SubscriptionSpec.cs
+++ b/src/IntegrationTests/SubscriptionSpec.cs
@@ -14,13 +14,13 @@ namespace IntegrationTests
 
 		public SubscriptionSpec ()
 		{
-			this.server = this.GetServer ();
+			server = GetServer ();
 		}
 
 		[Fact]
 		public async Task when_subscribe_topic_then_succeeds()
 		{
-			var client = this.GetClient ();
+			var client = GetClient ();
 			var topicFilter = Guid.NewGuid ().ToString () + "/#";
 
 			await client.SubscribeAsync (topicFilter, QualityOfService.AtMostOnce)
@@ -36,8 +36,8 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_subscribe_multiple_topics_then_succeeds()
 		{
-			var client = this.GetClient ();
-			var topicsToSubscribe = this.GetTestLoad();
+			var client = GetClient ();
+			var topicsToSubscribe = GetTestLoad();
 			var topics = new List<string> ();
 			var tasks = new List<Task> ();
 
@@ -60,8 +60,8 @@ namespace IntegrationTests
 		[Fact]
 		public async Task when_unsubscribe_topic_then_succeeds()
 		{
-			var client = this.GetClient ();
-			var topicsToSubscribe = this.GetTestLoad();
+			var client = GetClient ();
+			var topicsToSubscribe = GetTestLoad();
 			var topics = new List<string> ();
 			var tasks = new List<Task> ();
 
@@ -83,8 +83,8 @@ namespace IntegrationTests
 
 		public void Dispose ()
 		{
-			if (this.server != null) {
-				this.server.Stop ();
+			if (server != null) {
+				server.Stop ();
 			}
 		}
 	}

--- a/src/IntegrationTests/TestAuthenticationProvider.cs
+++ b/src/IntegrationTests/TestAuthenticationProvider.cs
@@ -15,7 +15,7 @@ namespace IntegrationTests
 
 		public bool Authenticate (string username, string password)
 		{
-			return username == this.expectedUsername && password == this.expectedPassword;
+			return username == expectedUsername && password == expectedPassword;
 		}
 	}
 }

--- a/src/IntegrationTests/TestTracerListener.cs
+++ b/src/IntegrationTests/TestTracerListener.cs
@@ -20,10 +20,10 @@ namespace IntegrationTests
 				message = string.Format (format, args);
 			}
 				
-			Debug.WriteLine (this.GetTestLogMessage (eventCache, message));
+			Debug.WriteLine (GetTestLogMessage (eventCache, message));
 		}
 
-		private string GetTestLogMessage(TraceEventCache eventCache, string message)
+		string GetTestLogMessage(TraceEventCache eventCache, string message)
 		{
 			return string.Format ("Thread {0} - {1} - {2}", eventCache.ThreadId.PadLeft(4), 
 				eventCache.DateTime.ToString("MM/dd/yyyy hh:mm:ss.fff").PadLeft(4), message);

--- a/src/Server/ConnectionProvider.cs
+++ b/src/Server/ConnectionProvider.cs
@@ -16,30 +16,30 @@ namespace System.Net.Mqtt.Server
 			connections = new ConcurrentDictionary<string, IChannel<IPacket>> ();
 		}
 
-		public int Connections { get { return connections.Skip(0).Count(); } }
+		public int Connections { get { return connections.Skip (0).Count (); } }
 
-		public IEnumerable<string> ActiveClients 
-		{ 
-			get 
-			{ 
+		public IEnumerable<string> ActiveClients
+		{
+			get
+			{
 				return connections
 					.Where (c => c.Value.IsConnected)
-					.Select (c => c.Key); 
-			} 
+					.Select (c => c.Key);
+			}
 		}
 
-		public void AddConnection(string clientId, IChannel<IPacket> connection)
-        {
+		public void AddConnection (string clientId, IChannel<IPacket> connection)
+		{
 			var existingConnection = default (IChannel<IPacket>);
 
 			if (connections.TryGetValue (clientId, out existingConnection)) {
 				tracer.Warn (Properties.Resources.Tracer_ConnectionProvider_ClientIdExists, clientId);
 
-				this.RemoveConnection (clientId);
+				RemoveConnection (clientId);
 			}
 
-			connections.TryAdd(clientId, connection);
-        }
+			connections.TryAdd (clientId, connection);
+		}
 
 		public IChannel<IPacket> GetConnection (string clientId)
 		{
@@ -49,7 +49,7 @@ namespace System.Net.Mqtt.Server
 				if (!existingConnection.IsConnected) {
 					tracer.Warn (Properties.Resources.Tracer_ConnectionProvider_ClientDisconnected, clientId);
 
-					this.RemoveConnection (clientId);
+					RemoveConnection (clientId);
 					existingConnection = default (IChannel<IPacket>);
 				}
 			}
@@ -58,8 +58,8 @@ namespace System.Net.Mqtt.Server
 		}
 
 		/// <exception cref="ProtocolException">ProtocolException</exception>
-        public void RemoveConnection(string clientId)
-        {
+		public void RemoveConnection (string clientId)
+		{
 			var existingConnection = default (IChannel<IPacket>);
 
 			if (connections.TryRemove (clientId, out existingConnection)) {
@@ -67,6 +67,6 @@ namespace System.Net.Mqtt.Server
 
 				existingConnection.Dispose ();
 			}
-        }
+		}
 	}
 }

--- a/src/Server/Flows/DisconnectFlow.cs
+++ b/src/Server/Flows/DisconnectFlow.cs
@@ -16,8 +16,8 @@ namespace System.Net.Mqtt.Flows
 		readonly IRepository<ClientSession> sessionRepository;
 		readonly IRepository<ConnectionWill> willRepository;
 
-		public DisconnectFlow (IConnectionProvider connectionProvider, 
-			IRepository<ClientSession> sessionRepository, 
+		public DisconnectFlow (IConnectionProvider connectionProvider,
+			IRepository<ClientSession> sessionRepository,
 			IRepository<ConnectionWill> willRepository)
 		{
 			this.connectionProvider = connectionProvider;
@@ -36,21 +36,21 @@ namespace System.Net.Mqtt.Flows
 
 				tracer.Info (Props.Resources.Tracer_DisconnectFlow_Disconnecting, clientId);
 
-				this.willRepository.Delete (w => w.ClientId == clientId);
+				willRepository.Delete (w => w.ClientId == clientId);
 
-				var session = this.sessionRepository.Get (s => s.ClientId == clientId);
+				var session = sessionRepository.Get (s => s.ClientId == clientId);
 
 				if (session == null) {
-					throw new MqttException (string.Format(Properties.Resources.SessionRepository_ClientSessionNotFound, clientId));
+					throw new MqttException (string.Format (Properties.Resources.SessionRepository_ClientSessionNotFound, clientId));
 				}
 
 				if (session.Clean) {
-					this.sessionRepository.Delete (session);
+					sessionRepository.Delete (session);
 
 					tracer.Info (Props.Resources.Tracer_Server_DeletedSessionOnDisconnect, clientId);
 				}
 
-				this.connectionProvider.RemoveConnection (clientId);
+				connectionProvider.RemoveConnection (clientId);
 			});
 		}
 	}

--- a/src/Server/Flows/ServerProtocolFlowProvider.cs
+++ b/src/Server/Flows/ServerProtocolFlowProvider.cs
@@ -20,7 +20,7 @@ namespace System.Net.Mqtt.Flows
 			IPacketIdProvider packetIdProvider,
 			IEventStream eventStream,
 			ProtocolConfiguration configuration)
-			: base(topicEvaluator, repositoryProvider, configuration)
+			: base (topicEvaluator, repositoryProvider, configuration)
 		{
 			this.authenticationProvider = authenticationProvider;
 			this.connectionProvider = connectionProvider;
@@ -37,15 +37,15 @@ namespace System.Net.Mqtt.Flows
 			var retainedRepository = repositoryProvider.GetRepository<RetainedMessage> ();
 			var senderFlow = new PublishSenderFlow (sessionRepository, configuration);
 
-			flows.Add (ProtocolFlowType.Connect, new ServerConnectFlow (this.authenticationProvider, sessionRepository, willRepository, senderFlow));
+			flows.Add (ProtocolFlowType.Connect, new ServerConnectFlow (authenticationProvider, sessionRepository, willRepository, senderFlow));
 			flows.Add (ProtocolFlowType.PublishSender, senderFlow);
 			flows.Add (ProtocolFlowType.PublishReceiver, new ServerPublishReceiverFlow (topicEvaluator, connectionProvider,
 				senderFlow, retainedRepository, sessionRepository, willRepository, packetIdProvider, eventStream, configuration));
-			flows.Add (ProtocolFlowType.Subscribe, new ServerSubscribeFlow (topicEvaluator, sessionRepository, 
+			flows.Add (ProtocolFlowType.Subscribe, new ServerSubscribeFlow (topicEvaluator, sessionRepository,
 				retainedRepository, packetIdProvider, senderFlow, configuration));
 			flows.Add (ProtocolFlowType.Unsubscribe, new ServerUnsubscribeFlow (sessionRepository));
 			flows.Add (ProtocolFlowType.Ping, new PingFlow ());
-			flows.Add (ProtocolFlowType.Disconnect, new DisconnectFlow (this.connectionProvider, sessionRepository, willRepository));
+			flows.Add (ProtocolFlowType.Disconnect, new DisconnectFlow (connectionProvider, sessionRepository, willRepository));
 
 			return flows;
 		}

--- a/src/Server/Flows/ServerUnsubscribeFlow.cs
+++ b/src/Server/Flows/ServerUnsubscribeFlow.cs
@@ -22,10 +22,10 @@ namespace System.Net.Mqtt.Flows
 			}
 
 			var unsubscribe = input as Unsubscribe;
-			var session = this.sessionRepository.Get (s => s.ClientId == clientId);
+			var session = sessionRepository.Get (s => s.ClientId == clientId);
 
 			if (session == null) {
-				throw new MqttException (string.Format(Properties.Resources.SessionRepository_ClientSessionNotFound, clientId));
+				throw new MqttException (string.Format (Properties.Resources.SessionRepository_ClientSessionNotFound, clientId));
 			}
 
 			foreach (var topic in unsubscribe.Topics) {
@@ -36,10 +36,10 @@ namespace System.Net.Mqtt.Flows
 				}
 			}
 
-			this.sessionRepository.Update(session);
+			sessionRepository.Update (session);
 
-			await channel.SendAsync(new UnsubscribeAck (unsubscribe.PacketId))
-				.ConfigureAwait(continueOnCapturedContext: false);
+			await channel.SendAsync (new UnsubscribeAck (unsubscribe.PacketId))
+				.ConfigureAwait (continueOnCapturedContext: false);
 		}
 	}
 }

--- a/src/Server/IConnectionProvider.cs
+++ b/src/Server/IConnectionProvider.cs
@@ -4,7 +4,7 @@ using System.Net.Mqtt.Packets;
 namespace System.Net.Mqtt.Server
 {
 	internal interface IConnectionProvider
-    {
+	{
 		int Connections { get; }
 
 		IEnumerable<string> ActiveClients { get; }
@@ -13,6 +13,6 @@ namespace System.Net.Mqtt.Server
 
 		IChannel<IPacket> GetConnection (string clientId);
 
-		void RemoveConnection(string clientId);
-    }
+		void RemoveConnection (string clientId);
+	}
 }

--- a/src/Server/NullAuthenticationProvider.cs
+++ b/src/Server/NullAuthenticationProvider.cs
@@ -4,12 +4,12 @@
 	{
 		private static readonly Lazy<NullAuthenticationProvider> instance;
 
-		static NullAuthenticationProvider()
+		static NullAuthenticationProvider ()
 		{
 			instance = new Lazy<NullAuthenticationProvider> (() => new NullAuthenticationProvider ());
 		}
 
-		private NullAuthenticationProvider()
+		NullAuthenticationProvider ()
 		{
 		}
 

--- a/src/Server/ServerInitializer.cs
+++ b/src/Server/ServerInitializer.cs
@@ -15,7 +15,7 @@ namespace System.Net.Mqtt.Server
 			this.channelProvider = channelProvider;
 		}
 
-		public Server Initialize(ProtocolConfiguration configuration)
+		public Server Initialize (ProtocolConfiguration configuration)
 		{
 			var topicEvaluator = new TopicEvaluator (configuration);
 			var channelFactory = new PacketChannelFactory (topicEvaluator, configuration);
@@ -23,13 +23,13 @@ namespace System.Net.Mqtt.Server
 			var connectionProvider = new ConnectionProvider ();
 			var packetIdProvider = new PacketIdProvider ();
 			var eventStream = new EventStream ();
-			var flowProvider = new ServerProtocolFlowProvider (this.authenticationProvider, connectionProvider, topicEvaluator, 
+			var flowProvider = new ServerProtocolFlowProvider (authenticationProvider, connectionProvider, topicEvaluator,
 				repositoryProvider, packetIdProvider, eventStream, configuration);
 
 			//TODO: The ChannelProvider injection must be handled better. I would not assume Tcp by default. 
 			//Instead I would delegate the implementation to a different NuGet or assembly.
 			//Maybe having one assembly per provider implementation (like TcpChannelProvider, WebSocketChannelProvider, TLSChannelProvider, etc)
-			return new Server (this.channelProvider ?? new TcpChannelProvider (configuration), channelFactory, 
+			return new Server (channelProvider ?? new TcpChannelProvider (configuration), channelFactory,
 				flowProvider, connectionProvider, eventStream, configuration);
 		}
 	}

--- a/src/Server/TcpChannelProvider.cs
+++ b/src/Server/TcpChannelProvider.cs
@@ -17,7 +17,7 @@ namespace System.Net.Mqtt.Server
 		public TcpChannelProvider (ProtocolConfiguration configuration)
 		{
 			this.configuration = configuration;
-			this.listener = new Lazy<TcpListener> (() => {
+			listener = new Lazy<TcpListener> (() => {
 				var tcpListener = new TcpListener(IPAddress.Any, this.configuration.Port);
 
 				try {
@@ -35,32 +35,32 @@ namespace System.Net.Mqtt.Server
 		/// <exception cref="MqttException">ProtocolException</exception>
 		public IObservable<IChannel<byte[]>> GetChannels ()
 		{
-			if (this.disposed) {
-				throw new ObjectDisposedException (this.GetType ().FullName);
+			if (disposed) {
+				throw new ObjectDisposedException (GetType ().FullName);
 			}
 
 			return Observable
 				.FromAsync (() => {
-					return Task.Factory.FromAsync<TcpClient> (this.listener.Value.BeginAcceptTcpClient,
-						this.listener.Value.EndAcceptTcpClient, TaskCreationOptions.AttachedToParent);
+					return Task.Factory.FromAsync<TcpClient> (listener.Value.BeginAcceptTcpClient,
+						listener.Value.EndAcceptTcpClient, TaskCreationOptions.AttachedToParent);
 				})
 				.Repeat ()
-				.Select (client => new TcpChannel (client, new PacketBuffer (), this.configuration));
+				.Select (client => new TcpChannel (client, new PacketBuffer (), configuration));
 		}
 
 		public void Dispose ()
 		{
-			this.Dispose (true);
+			Dispose (true);
 			GC.SuppressFinalize (this);
 		}
 
 		protected virtual void Dispose (bool disposing)
 		{
-			if (this.disposed) return;
+			if (disposed) return;
 
 			if (disposing) {
-				this.listener.Value.Stop ();
-				this.disposed = true;
+				listener.Value.Stop ();
+				disposed = true;
 			}
 		}
 	}

--- a/src/Tests/Formatters/EmptyPacketFormatterSpec.cs
+++ b/src/Tests/Formatters/EmptyPacketFormatterSpec.cs
@@ -18,8 +18,8 @@ namespace Tests.Formatters
 
 		public EmptyPacketFormatterSpec ()
 		{
-			this.packetChannel = new Mock<IChannel<IPacket>> ();
-			this.byteChannel = new Mock<IChannel<byte[]>> ();
+			packetChannel = new Mock<IChannel<IPacket>> ();
+			byteChannel = new Mock<IChannel<byte[]>> ();
 		}
 		
 		[Theory]
@@ -30,7 +30,7 @@ namespace Tests.Formatters
 		{
 			packetPath = Path.Combine (Environment.CurrentDirectory, packetPath);
 
-			var formatter = this.GetFormatter (packetType, type);
+			var formatter = GetFormatter (packetType, type);
 			var packet = Packet.ReadAllBytes (packetPath);
 
 			var result = await formatter.FormatAsync (packet)
@@ -47,7 +47,7 @@ namespace Tests.Formatters
 		{
 			packetPath = Path.Combine (Environment.CurrentDirectory, packetPath);
 
-			var formatter = this.GetFormatter (packetType, type);
+			var formatter = GetFormatter (packetType, type);
 			var packet = Packet.ReadAllBytes (packetPath);
 			
 			var ex = Assert.Throws<AggregateException> (() => formatter.FormatAsync (packet).Wait());
@@ -64,7 +64,7 @@ namespace Tests.Formatters
 			packetPath = Path.Combine (Environment.CurrentDirectory, packetPath);
 
 			var expectedPacket = Packet.ReadAllBytes (packetPath);
-			var formatter = this.GetFormatter (packetType, type);
+			var formatter = GetFormatter (packetType, type);
 			var packet = Activator.CreateInstance (type) as IPacket;
 
 			var result = await formatter.FormatAsync (packet)
@@ -73,7 +73,7 @@ namespace Tests.Formatters
 			Assert.Equal (expectedPacket, result);
 		}
 
-		private IFormatter GetFormatter(PacketType packetType, Type type)
+		IFormatter GetFormatter(PacketType packetType, Type type)
 		{
 			var genericType = typeof (EmptyPacketFormatter<>);
 			var formatterType = genericType.MakeGenericType (type);

--- a/src/Tests/Formatters/PublishFormatterSpec.cs
+++ b/src/Tests/Formatters/PublishFormatterSpec.cs
@@ -18,8 +18,8 @@ namespace Tests.Formatters
 
 		public PublishFormatterSpec ()
 		{
-			this.packetChannel = new Mock<IChannel<IPacket>> ();
-			this.byteChannel = new Mock<IChannel<byte[]>> ();
+			packetChannel = new Mock<IChannel<IPacket>> ();
+			byteChannel = new Mock<IChannel<byte[]>> ();
 		}
 		
 		[Theory]

--- a/src/Tests/Packet.cs
+++ b/src/Tests/Packet.cs
@@ -82,12 +82,12 @@ namespace Tests
 			return Deserialize (text, type);
 		}
 
-		private static T Deserialize<T>(string serialized)
+		static T Deserialize<T>(string serialized)
         {
 			return JsonConvert.DeserializeObject<T> (serialized, new StringByteArrayConverter());
         }
 
-		private static object Deserialize(string serialized, Type type)
+		static object Deserialize(string serialized, Type type)
         {
 			return JsonConvert.DeserializeObject (serialized, type, new StringByteArrayConverter());
         }

--- a/src/Tests/ProtocolEncodingSpec.cs
+++ b/src/Tests/ProtocolEncodingSpec.cs
@@ -22,7 +22,7 @@ namespace Tests
 		[Fact]
 		public void when_encoding_string_with_exceeded_length_then_fails()
 		{
-			var text = this.GetRandomString (size: 65537);
+			var text = GetRandomString (size: 65537);
 
 			Assert.Throws<MqttException>(() => Protocol.Encoding.EncodeString (text));
 		}
@@ -271,7 +271,7 @@ namespace Tests
 			Assert.Throws<MqttException> (() => Protocol.Encoding.DecodeRemainingLength (bytes.ToArray (), out arrayLength));
 		}
 
-		private string GetRandomString(int size)
+		string GetRandomString(int size)
 		{
 			var random = new Random();
 			var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";


### PR DESCRIPTION
- We need to ensure that SingleThreadTaskScheduler is properly disposed when it's not needed anymore. This scheduler has a custom Thread and a BlockingCollection that never completes, unless the class is disposed.
- This was causing living threads to never ends, even after Client and Server are disposed 
- This PR also contains a massive code formatting and also  pending improvement on an Integration Test
