### PR TITLE
Removed System.Runtime.Serialization.Primitives and DataContract usage

### DIFF
--- a/src/Client/Client.csproj
+++ b/src/Client/Client.csproj
@@ -118,11 +118,6 @@
     <None Include="Client.nuspec" />
     <None Include="project.json" />
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Runtime.Serialization.Primitives">
-      <HintPath>..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.5\Profile\Profile111\System.Runtime.Serialization.Primitives.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\Hermes.targets" />
   <ProjectExtensions>

--- a/src/Client/Exceptions/MqttClientException.cs
+++ b/src/Client/Exceptions/MqttClientException.cs
@@ -1,8 +1,5 @@
-﻿using System.Runtime.Serialization;
-
-namespace System.Net.Mqtt.Exceptions
+﻿namespace System.Net.Mqtt.Exceptions
 {
-    [DataContract]
 	public class MqttClientException : MqttException
     {
 		public MqttClientException ()

--- a/src/Client/Exceptions/MqttConnectionException.cs
+++ b/src/Client/Exceptions/MqttConnectionException.cs
@@ -1,9 +1,7 @@
 ﻿using System.Net.Mqtt.Packets;
-using System.Runtime.Serialization;
 
 namespace System.Net.Mqtt.Exceptions
 {
-	[DataContract]
 	public class MqttConnectionException : MqttException
 	{
 		public MqttConnectionException (MqttConnectionStatus status)

--- a/src/Client/Exceptions/MqttException.cs
+++ b/src/Client/Exceptions/MqttException.cs
@@ -1,8 +1,5 @@
-﻿using System.Runtime.Serialization;
-
-namespace System.Net.Mqtt.Exceptions
+﻿namespace System.Net.Mqtt.Exceptions
 {
-	[DataContract]
 	public class MqttException : Exception
 	{
 		public MqttException ()

--- a/src/Client/Exceptions/MqttRepositoryException.cs
+++ b/src/Client/Exceptions/MqttRepositoryException.cs
@@ -1,8 +1,5 @@
-﻿using System.Runtime.Serialization;
-
-namespace System.Net.Mqtt.Exceptions
+﻿namespace System.Net.Mqtt.Exceptions
 {
-	[DataContract]
 	public class MqttRepositoryException : MqttException
     {
 		public MqttRepositoryException ()

--- a/src/Client/Exceptions/MqttViolationException.cs
+++ b/src/Client/Exceptions/MqttViolationException.cs
@@ -1,8 +1,5 @@
-﻿using System.Runtime.Serialization;
-
-namespace System.Net.Mqtt.Exceptions
+﻿namespace System.Net.Mqtt.Exceptions
 {
-	[DataContract]
 	public class MqttViolationException : MqttException
 	{
 		public MqttViolationException ()

--- a/src/Server/Exceptions/MqttServerException.cs
+++ b/src/Server/Exceptions/MqttServerException.cs
@@ -1,9 +1,7 @@
 ﻿using System.Net.Mqtt.Exceptions;
-using System.Runtime.Serialization;
 
 namespace System.Net.Mqtt.Server.Exceptions
 {
-	[DataContract]
 	public class MqttServerException : MqttException
 	{
 		public MqttServerException ()

--- a/src/Server/Server.csproj
+++ b/src/Server/Server.csproj
@@ -49,11 +49,6 @@
       <Name>Client</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Runtime.Serialization.Primitives">
-      <HintPath>..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.5\Profile\Profile111\System.Runtime.Serialization.Primitives.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\Hermes.targets" />
 </Project>


### PR DESCRIPTION
- This makes the exceptions non serializable, but it's needed to support netstandard
