### PR TITLE
Introduce a connection timeout control

### DIFF
--- a/src/Client/MqttConfiguration.cs
+++ b/src/Client/MqttConfiguration.cs
@@ -18,6 +18,7 @@
 			MaximumQualityOfService = MqttQualityOfService.AtMostOnce;
 			KeepAliveSecs = 0;
 			WaitTimeoutSecs = 5;
+			ConnectionTimeoutSecs = 5;
 			AllowWildcardsInTopicFilters = true;
 		}
 
@@ -51,6 +52,13 @@
         /// Default value is 5 seconds
         /// </summary>
 		public int WaitTimeoutSecs { get; set; }
+
+        /// <summary>
+        /// Seconds to wait for a channel connection until the operation timeouts.
+        /// This value is generally used to wait for the MQTT channel to open.
+        /// Default value is 5 seconds
+        /// </summary>
+		public int ConnectionTimeoutSecs { get; set; }
 
         /// <summary>
         /// Determines if multi level (#)  and single level (+)

--- a/src/Client/Sdk/Bindings/TcpChannelFactory.cs
+++ b/src/Client/Sdk/Bindings/TcpChannelFactory.cs
@@ -22,15 +22,33 @@ namespace System.Net.Mqtt.Sdk.Bindings
 			var tcpClient = new TcpClient ();
 
 			try {
-				await tcpClient
-                    .ConnectAsync (hostAddress, configuration.Port)
-                    .ConfigureAwait (continueOnCapturedContext: false);
+				var connectTask = tcpClient.ConnectAsync (hostAddress, configuration.Port);
+				var timeoutTask = Task.Delay (TimeSpan.FromSeconds (configuration.ConnectionTimeoutSecs));
+
+				var maybeTimeout = await Task.WhenAny (connectTask, timeoutTask)
+				                             .ConfigureAwait (continueOnCapturedContext: false);
+
+				if (maybeTimeout == timeoutTask)
+					throw new TimeoutException ();
 			} catch (SocketException socketEx) {
 				var message = string.Format (Properties.Resources.TcpChannelFactory_TcpClient_Failed, hostAddress, configuration.Port);
 
 				tracer.Error (socketEx, message);
 
 				throw new MqttException (message, socketEx);
+			} catch (TimeoutException tex) {
+				try {
+					// Just in case the connection is a little late,
+					// dispose the tcpClient. This may throw an exception,
+					// which we should just eat.
+					tcpClient.Dispose ();
+				} catch {}
+
+				var message = string.Format (Properties.Resources.TcpChannelFactory_TcpClient_Failed, hostAddress, configuration.Port);
+
+				tracer.Error(tex, message);
+
+				throw new MqttException (message, tex);
 			}
 
 			return new TcpChannel (tcpClient, new PacketBuffer (), configuration);


### PR DESCRIPTION
For now, controls the connect timeout on the TcpClient that underlies TcpChannel.
As `ConnectAsync` doesn't have any timeout or cancellation token overloads, simulates
a timeout by spawning a delay task simultaneously, and waiting to see which task will finish first.

Other bindings can implement this in other ways.