### PR TITLE
Bug fixing

### DIFF
--- a/src/Client/Sdk/Bindings/TcpChannelFactory.cs
+++ b/src/Client/Sdk/Bindings/TcpChannelFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Net.Sockets;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 
 namespace System.Net.Mqtt.Sdk.Bindings
@@ -31,7 +32,7 @@ namespace System.Net.Mqtt.Sdk.Bindings
 					throw new TimeoutException ();
 
 				if (resultTask.IsFaulted)
-					throw resultTask.Exception.InnerException;
+					ExceptionDispatchInfo.Capture (resultTask.Exception.InnerException).Throw ();
 			} catch (SocketException socketEx) {
 				var message = string.Format (Properties.Resources.TcpChannelFactory_TcpClient_Failed, hostAddress, configuration.Port);
 

--- a/src/Client/Sdk/ClientPacketListener.cs
+++ b/src/Client/Sdk/ClientPacketListener.cs
@@ -92,6 +92,10 @@ namespace System.Net.Mqtt.Sdk
 						return;
 					}
 
+					if (configuration.KeepAliveSecs > 0) {
+						StartKeepAliveMonitor ();
+					}
+
 					await DispatchPacketAsync (packet)
 						.ConfigureAwait (continueOnCapturedContext: false);
 				}, ex => {
@@ -129,16 +133,12 @@ namespace System.Net.Mqtt.Sdk
 
 		IDisposable ListenSentConnectPacket ()
 		{
-			return channel.SenderStream
+			return channel
+				.SenderStream
 				.OfType<Connect> ()
 				.FirstAsync ()
-				.ObserveOn (NewThreadScheduler.Default)
 				.Subscribe (connect => {
 					clientId = connect.ClientId;
-
-					if (configuration.KeepAliveSecs > 0) {
-						StartKeepAliveMonitor ();
-					}
 				});
 		}
 

--- a/src/Client/Sdk/IMqttChannelFactory.cs
+++ b/src/Client/Sdk/IMqttChannelFactory.cs
@@ -8,10 +8,11 @@ namespace System.Net.Mqtt.Sdk
     /// </summary>
 	public interface IMqttChannelFactory
 	{
-        /// <summary>
-        /// Creates instances of <see cref="IMqttChannel{T}"/> of byte[].
-        /// </summary>
-        /// <returns>An MQTT channel of byte[].</returns>
+		/// <summary>
+		/// Creates instances of <see cref="IMqttChannel{T}"/> of byte[].
+		/// </summary>
+		/// <returns>An MQTT channel of byte[].</returns>
+		/// <exception cref="MqttException">MqttException</exception>
 		Task<IMqttChannel<byte[]>> CreateAsync ();
 	}
 }

--- a/src/Tests/TcpChannelFactorySpec.cs
+++ b/src/Tests/TcpChannelFactorySpec.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Net;
+using System.Net.Mqtt;
+using System.Net.Mqtt.Sdk.Bindings;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Tests
+{
+	public class TcpChannelFactorySpec
+	{
+		[Fact]
+		public async Task when_creating_channel_then_succeeds()
+		{
+			var configuration = new MqttConfiguration { ConnectionTimeoutSecs = 2 };
+			var listener = new TcpListener (IPAddress.Loopback, configuration.Port);
+
+			listener.Start ();
+
+			var factory = new TcpChannelFactory (IPAddress.Loopback.ToString (), configuration);
+			var channel = await factory.CreateAsync ();
+
+			Assert.NotNull (channel);
+			Assert.True (channel.IsConnected);
+
+			listener.Stop ();
+		}
+
+		[Fact]
+		public void when_creating_channel_with_invalid_address_then_fails()
+		{
+			var configuration = new MqttConfiguration { ConnectionTimeoutSecs = 2 };
+			var factory = new TcpChannelFactory (IPAddress.Loopback.ToString (), configuration);
+
+			var ex = Assert.Throws<AggregateException> (() => factory.CreateAsync ().Result);
+
+			Assert.NotNull (ex);
+			Assert.NotNull (ex.InnerException);
+			Assert.True (ex.InnerException is MqttException);
+			Assert.NotNull (ex.InnerException.InnerException);
+			Assert.True (ex.InnerException.InnerException is SocketException);
+		}
+	}
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ProtocolEncodingSpec.cs" />
     <Compile Include="StringByteArrayConverter.cs" />
+    <Compile Include="TcpChannelFactorySpec.cs" />
     <Compile Include="TopicEvaluatorSpec.cs" />
     <Compile Include="VersionInfoSpec.cs" />
   </ItemGroup>


### PR DESCRIPTION
* Fixed issues in TcpChannelFactory:
   - After latest changes adding connection timeout, an issue has been introduced which swallows any exception that occurs as part of the initial TCP connection
   - This fix allows to re throw those exceptions
   - Also, this fix adds missing unit tests over TcpChannelFactory

* Moved Client keep alive monitoring to start after the Connect Ack is received:
   - Previously, the keep alive monitoring started immediately after the Connect packet was sent from the client. Now, the keep alive starts once the ConnectAck is received from Server.
   - This strategy is aligned with the MQTT spec and also avoids unnecessary errors when the client connection couldn't be performed
