### PR TITLE
Avoid throwing exceptions to Client Message Stream

### DIFF
--- a/src/Client/Sdk/MqttClientImpl.cs
+++ b/src/Client/Sdk/MqttClientImpl.cs
@@ -307,7 +307,6 @@ namespace System.Net.Mqtt.Sdk
 		void Close (Exception ex)
 		{
 			tracer.Error (ex);
-			receiver.OnError (ex);
 			Close (DisconnectedReason.Error, ex.Message);
 		}
 


### PR DESCRIPTION
- Given that every MQTT Client API operation can throw the corresponding protocol exceptions, there is no reason to make the MessageStream to also fail under any circumstances. Given that MessageStream could be used in many ways, pushing exceptions to it can lead to unwanted behaviors on the client side as well a confusions of what the MessageStream responsibility is. Currently, almost any error on the lower layers was being pushed to the MessageStream, even NullReferenceException and ObjectDisposedException
- This fix removes the exception pushing to the MessageStream, so only the Client API calls can now throw errors