### PR TITLE
Fixed bug on Connect Flow

### DIFF
--- a/src/Tests/Flows/ConnectFlowSpec.cs
+++ b/src/Tests/Flows/ConnectFlowSpec.cs
@@ -1,13 +1,15 @@
 ﻿using Moq;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Net.Mqtt;
+using System.Net.Mqtt.Sdk;
 using System.Net.Mqtt.Sdk.Flows;
 using System.Net.Mqtt.Sdk.Packets;
 using System.Net.Mqtt.Sdk.Storage;
 using System.Threading.Tasks;
 using Xunit;
-using System.Net.Mqtt.Sdk;
 
 namespace Tests.Flows
 {
@@ -261,6 +263,124 @@ namespace Tests.Flows
 			Assert.NotNull (aggregateEx.InnerException);
 			Assert.True (aggregateEx.InnerException is MqttConnectionException);
 			Assert.Equal (MqttConnectionStatus.BadUserNameOrPassword, ((MqttConnectionException)aggregateEx.InnerException).ReturnCode);
+		}
+
+		[Fact]
+		public async Task when_sending_connect_with_existing_session_and_without_clean_session_then_pending_messages_and_acks_are_sent()
+		{
+			var authenticationProvider = Mock.Of<IMqttAuthenticationProvider>(p => p.Authenticate(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()) == true);
+			var sessionRepository = new Mock<IRepository<ClientSession>>();
+			var willRepository = new Mock<IRepository<ConnectionWill>>();
+
+			var clientId = Guid.NewGuid().ToString();
+			var existingSession = new ClientSession { ClientId = clientId, Clean = false };
+
+			var topic = "foo/bar";
+			var payload = new byte[10];
+			var qos = MqttQualityOfService.ExactlyOnce;
+			var packetId = (ushort)10;
+
+			existingSession.PendingMessages = new List<PendingMessage>
+			{
+				new PendingMessage {
+					Status = PendingMessageStatus.PendingToSend,
+					Topic = topic,
+					QualityOfService = qos,
+					Retain = false,
+					Duplicated = false,
+					PacketId = packetId,
+					Payload = payload
+				},
+				new PendingMessage {
+					Status = PendingMessageStatus.PendingToAcknowledge,
+					Topic = topic,
+					QualityOfService = qos,
+					Retain = false,
+					Duplicated = false,
+					PacketId = packetId,
+					Payload = payload
+				}
+			};
+
+			existingSession.PendingAcknowledgements = new List<PendingAcknowledgement>
+			{
+				new PendingAcknowledgement { Type = MqttPacketType.PublishReceived, PacketId = packetId }
+			};
+
+			sessionRepository
+				.Setup(r => r.Get(It.IsAny<Expression<Func<ClientSession, bool>>>()))
+				.Returns(existingSession);
+
+			var senderFlow = new Mock<IPublishSenderFlow>();
+
+			senderFlow
+				.Setup(f => f.SendPublishAsync(It.IsAny<string>(), It.IsAny<Publish>(), It.IsAny<IMqttChannel<IPacket>>(), It.IsAny<PendingMessageStatus>()))
+				.Callback<string, Publish, IMqttChannel<IPacket>, PendingMessageStatus>(async (id, pub, ch, stat) =>
+				{
+					await ch.SendAsync(pub);
+				})
+				.Returns(Task.Delay(0));
+
+			senderFlow
+				.Setup(f => f.SendAckAsync(It.IsAny<string>(), It.IsAny<IFlowPacket>(), It.IsAny<IMqttChannel<IPacket>>(), It.IsAny<PendingMessageStatus>()))
+				.Callback<string, IFlowPacket, IMqttChannel<IPacket>, PendingMessageStatus>(async (id, pack, ch, stat) =>
+				{
+					await ch.SendAsync(pack);
+				})
+				.Returns(Task.Delay(0));
+
+			var connect = new Connect(clientId, cleanSession: false);
+			var channel = new Mock<IMqttChannel<IPacket>>();
+			var firstPacket = default(IPacket);
+			var nextPackets = new List<IPacket>();
+
+			channel
+				.Setup(c => c.SendAsync(It.IsAny<IPacket>()))
+				.Callback<IPacket>(packet =>
+				{
+					if (firstPacket == default(IPacket))
+					{
+						firstPacket = packet;
+					}
+					else
+					{
+						nextPackets.Add(packet);
+					}
+				})
+				.Returns(Task.Delay(0));
+
+			var connectionProvider = new Mock<IConnectionProvider>();
+
+			connectionProvider
+				.Setup(p => p.GetConnection(It.Is<string>(c => c == clientId)))
+				.Returns(channel.Object);
+
+			var flow = new ServerConnectFlow(authenticationProvider, sessionRepository.Object, willRepository.Object, senderFlow.Object);
+
+			await flow.ExecuteAsync(clientId, connect, channel.Object)
+				.ConfigureAwait(continueOnCapturedContext: false);
+
+			sessionRepository.Verify(r => r.Create(It.IsAny<ClientSession>()), Times.Never);
+			sessionRepository.Verify(r => r.Delete(It.IsAny<Expression<Func<ClientSession, bool>>>()), Times.Never);
+			sessionRepository.Verify(r => r.Update(It.IsAny<ClientSession>()), Times.Once);
+			willRepository.Verify(r => r.Create(It.IsAny<ConnectionWill>()), Times.Never);
+			senderFlow.Verify(f => f.SendPublishAsync(It.Is<string>(x => x == existingSession.ClientId),
+				It.Is<Publish>(x => x.Topic == topic && x.QualityOfService == qos && x.PacketId == packetId),
+				It.IsAny<IMqttChannel<IPacket>>(),
+				It.IsAny<PendingMessageStatus>()), Times.Exactly(2));
+			senderFlow.Verify(f => f.SendAckAsync(It.Is<string>(x => x == existingSession.ClientId),
+				It.Is<IFlowPacket>(x => x.Type == MqttPacketType.PublishReceived && x.PacketId == packetId),
+				It.IsAny<IMqttChannel<IPacket>>(),
+				It.Is<PendingMessageStatus>(x => x == PendingMessageStatus.PendingToAcknowledge)), Times.Once);
+
+			var connectAck = firstPacket as ConnectAck;
+
+			Assert.True(connectAck != null, userMessage: "The first packet sent by the Server must be a CONNACK");
+			Assert.Equal(MqttPacketType.ConnectAck, connectAck.Type);
+			Assert.Equal(MqttConnectionStatus.Accepted, connectAck.Status);
+			Assert.True(connectAck.SessionPresent);
+			Assert.Equal(3, nextPackets.Count);
+			Assert.False(nextPackets.Any(x => x is ConnectAck));
 		}
 	}
 }


### PR DESCRIPTION
- For the particular case where the user session was preserved on connection (by using CleanSession = false) and there were pending messages to deliver by the Broker (pending Publish or Ack messages),
then the Server Connect Flow was failing because the pending messages were sent before the Connect Ack, which is a violation of the MQTT protocol, where it says that the first message that the Server must send is a Connect Ack

- Added a proper Unit Test to detect and cover this case