### PR TITLE
Fixed wrong Client package version dependency on Server .nuspec

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -17,6 +17,7 @@
 
 	<PropertyGroup>
 		<GenerateNuspecDependsOn>SetVersions;$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
+		<GetPackageVersionDependsOn>SetVersions;$(GetPackageVersionDependsOn)</GetPackageVersionDependsOn>
 	</PropertyGroup>
 
 	<Target Name="SetVersions" BeforeTargets="GetAssemblyVersion" DependsOnTargets="GitVersion" Returns="$(Version)">


### PR DESCRIPTION
- An incorrect version was being added to the Server .nuspec, causing incorrect package installations (e.g: System.Net.Mqtt.0.5.9-beta was including System.Net.Mqtt.1.0.0)