### PR TITLE
1 - Implemented client instance re using

### DIFF
--- a/src/Client/Client.csproj
+++ b/src/Client/Client.csproj
@@ -14,6 +14,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Update="Properties\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Update="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/src/Client/Properties/Resources.Designer.cs
+++ b/src/Client/Properties/Resources.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace System.Net.Mqtt.Properties {
     using System;
-	using System.Reflection;
     
     
     /// <summary>
@@ -40,7 +39,7 @@ namespace System.Net.Mqtt.Properties {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("System.Net.Mqtt.Properties.Resources", typeof(Resources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("System.Net.Mqtt.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -80,11 +79,38 @@ namespace System.Net.Mqtt.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The protocol connection cannot be performed because an active connection for client {0} already exists.
+        /// </summary>
+        internal static string Client_AlreadyConnected {
+            get {
+                return ResourceManager.GetString("Client_AlreadyConnected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The protocol disconnection cannot be performed because the client is already disconnected.
+        /// </summary>
+        internal static string Client_AlreadyDisconnected {
+            get {
+                return ResourceManager.GetString("Client_AlreadyDisconnected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Client {0} - Cleaned old session.
         /// </summary>
         internal static string Client_CleanedOldSession {
             get {
                 return ResourceManager.GetString("Client_CleanedOldSession", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Client {0} - Closing. Reason: {1}.
+        /// </summary>
+        internal static string Client_Closing {
+            get {
+                return ResourceManager.GetString("Client_Closing", resourceCulture);
             }
         }
         
@@ -134,20 +160,11 @@ namespace System.Net.Mqtt.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Client {0} - Removed client session as part of Disconnect.
+        ///   Looks up a localized string similar to Client {0} - Removed client session.
         /// </summary>
         internal static string Client_DeletedSessionOnDisconnect {
             get {
                 return ResourceManager.GetString("Client_DeletedSessionOnDisconnect", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Client {0} - Disposing. Reason: {1}.
-        /// </summary>
-        internal static string Client_Disposing {
-            get {
-                return ResourceManager.GetString("Client_Disposing", resourceCulture);
             }
         }
         
@@ -494,7 +511,7 @@ namespace System.Net.Mqtt.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The underlying communication stream is not available. The socket could became disconnected.
+        ///   Looks up a localized string similar to The underlying communication stream is not available. The socket could have been disconnected.
         /// </summary>
         internal static string MqttChannel_StreamDisconnected {
             get {

--- a/src/Client/Properties/Resources.resx
+++ b/src/Client/Properties/Resources.resx
@@ -178,10 +178,10 @@
     <value>Client {0} - Created new client session</value>
   </data>
   <data name="Client_DeletedSessionOnDisconnect" xml:space="preserve">
-    <value>Client {0} - Removed client session as part of Disconnect</value>
+    <value>Client {0} - Removed client session</value>
   </data>
-  <data name="Client_Disposing" xml:space="preserve">
-    <value>Client {0} - Disposing. Reason: {1}</value>
+  <data name="Client_Closing" xml:space="preserve">
+    <value>Client {0} - Closing. Reason: {1}</value>
   </data>
   <data name="Client_PacketsObservableCompleted" xml:space="preserve">
     <value>Client - Packet observable sequence has been completed, hence closing the channel</value>
@@ -335,5 +335,11 @@
   </data>
   <data name="Client_SubscriptionRejected" xml:space="preserve">
     <value>The server has rejected the subscription of client {0} to topic {1}</value>
+  </data>
+  <data name="Client_AlreadyConnected" xml:space="preserve">
+    <value>The protocol connection cannot be performed because an active connection for client {0} already exists</value>
+  </data>
+  <data name="Client_AlreadyDisconnected" xml:space="preserve">
+    <value>The protocol disconnection cannot be performed because the client is already disconnected</value>
   </data>
 </root>

--- a/src/Client/Sdk/Flows/ProtocolFlowProvider.cs
+++ b/src/Client/Sdk/Flows/ProtocolFlowProvider.cs
@@ -11,6 +11,7 @@ namespace System.Net.Mqtt.Sdk.Flows
 		protected readonly IRepositoryProvider repositoryProvider;
 		protected readonly MqttConfiguration configuration;
 
+		readonly object lockObject = new object ();
 		IDictionary<ProtocolFlowType, IProtocolFlow> flows;
 
 		protected ProtocolFlowProvider (IMqttTopicEvaluator topicEvaluator,
@@ -60,8 +61,12 @@ namespace System.Net.Mqtt.Sdk.Flows
 
 		IDictionary<ProtocolFlowType, IProtocolFlow> GetFlows ()
 		{
-			if (flows == default (IDictionary<ProtocolFlowType, IProtocolFlow>)) {
-				flows = InitializeFlows ();
+			if (flows == null) {
+				lock (lockObject) {
+					if (flows == null){
+						flows = InitializeFlows ();
+					}
+				}
 			}
 
 			return flows;

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -11,6 +11,7 @@
 
 	<ItemGroup Condition="'$(IncludeTesting)' == 'true'">
 		<PackageReference Include="xunit" Version="2.2.*" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.*" />
 		<PackageReference Include="Moq" Version="*" />
 		<PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
 	</ItemGroup>

--- a/src/IntegrationTests/ConnectionSpec.cs
+++ b/src/IntegrationTests/ConnectionSpec.cs
@@ -17,27 +17,31 @@ namespace IntegrationTests
 	{
 		readonly IMqttServer server;
 
-		public ConnectionSpec ()
+		public ConnectionSpec()
 		{
-			server = GetServerAsync ().Result;
+			server = GetServerAsync().Result;
 		}
 
-        [Fact]
-        public async Task when_connecting_client_to_non_existing_server_then_fails()
-        {
-            try
-            {
-                await GetClientAsync();
-            }
-            catch (Exception ex)
-            {
-                Assert.True(ex is MqttClientException);
-                Assert.NotNull(ex.InnerException);
-                Assert.True(ex.InnerException is MqttException);
-                Assert.NotNull(ex.InnerException.InnerException);
-                Assert.True(ex.InnerException.InnerException is SocketException);
-            }
-        }
+		[Fact]
+		public async Task when_connecting_client_to_non_existing_server_then_fails()
+		{
+			try
+			{
+				server.Dispose();
+
+				var client = await GetClientAsync();
+
+				await client.ConnectAsync(new MqttClientCredentials(GetClientId()));
+			}
+			catch (Exception ex)
+			{
+				Assert.True(ex is MqttClientException);
+				Assert.NotNull(ex.InnerException);
+				Assert.True(ex.InnerException is MqttException);
+				Assert.NotNull(ex.InnerException.InnerException);
+				Assert.True(ex.InnerException.InnerException is SocketException);
+			}
+		}
 
 		[Fact]
 		public async Task when_clients_connect_and_disconnect_then_server_raises_events()
@@ -75,333 +79,347 @@ namespace IntegrationTests
 
 			Assert.Equal(new[] { clientId2, clientId1 }, disconnected);
 			Assert.Equal(0, connected.Count);
+
+			fooClient.Dispose();
+			barClient.Dispose();
 		}
 
 		[Fact]
 		public async Task when_connect_clients_and_one_client_drops_connection_then_other_client_survives()
 		{
-			var fooClient = await GetClientAsync ();
-			var barClient = await GetClientAsync ();
+			var fooClient = await GetClientAsync();
+			var barClient = await GetClientAsync();
 
-			await fooClient.ConnectAsync (new MqttClientCredentials (GetClientId ()));
-			await barClient.ConnectAsync (new MqttClientCredentials (GetClientId ()));
+			await fooClient.ConnectAsync(new MqttClientCredentials(GetClientId()));
+			await barClient.ConnectAsync(new MqttClientCredentials(GetClientId()));
 
-            var initialConnectedClients = server.ActiveClients.Count ();
+			var initialConnectedClients = server.ActiveClients.Count();
 			var exceptionThrown = false;
 
-			try {
+			try
+			{
 				//Force an exception to be thrown by publishing null message
-				await fooClient.PublishAsync (message: null, qos: MqttQualityOfService.AtMostOnce);
-			} catch {
+				await fooClient.PublishAsync(message: null, qos: MqttQualityOfService.AtMostOnce);
+			}
+			catch
+			{
 				exceptionThrown = true;
 			}
 
-			var serverSignal = new ManualResetEventSlim ();
+			var serverSignal = new ManualResetEventSlim();
 
-			while (!serverSignal.IsSet) {
-				if (server.ActiveConnections == 1 && server.ActiveClients.Count () == 1) {
-					serverSignal.Set ();
+			while (!serverSignal.IsSet)
+			{
+				if (server.ActiveConnections == 1 && server.ActiveClients.Count() == 1)
+				{
+					serverSignal.Set();
 				}
 			}
 
-			serverSignal.Wait ();
+			serverSignal.Wait();
 
-            Assert.Equal (2, initialConnectedClients);
-			Assert.True (exceptionThrown);
-			Assert.Equal (1, server.ActiveConnections);
-			Assert.Equal (1, server.ActiveClients.Count ());
+			Assert.Equal(2, initialConnectedClients);
+			Assert.True(exceptionThrown);
+			Assert.Equal(1, server.ActiveConnections);
+			Assert.Equal(1, server.ActiveClients.Count());
 
-            fooClient.Dispose ();
-			barClient.Dispose ();
+			fooClient.Dispose();
+			barClient.Dispose();
 		}
 
 		[Fact]
 		public async Task when_connect_clients_then_succeeds()
 		{
-			var count = GetTestLoad ();
-			var clients = new List<IMqttClient> ();
-			var tasks = new List<Task> ();
+			var count = GetTestLoad();
+			var clients = new List<IMqttClient>();
+			var tasks = new List<Task>();
 
-			for (var i = 1; i <= count; i++) {
-				var client = await GetClientAsync ();
+			for (var i = 1; i <= count; i++)
+			{
+				var client = await GetClientAsync();
 
-				tasks.Add (client.ConnectAsync (new MqttClientCredentials (GetClientId ())));
-				clients.Add (client);
+				tasks.Add(client.ConnectAsync(new MqttClientCredentials(GetClientId())));
+				clients.Add(client);
 			}
 
-			await Task.WhenAll (tasks);
+			await Task.WhenAll(tasks);
 
-			Assert.Equal (count, server.ActiveClients.Count ());
-			Assert.True (clients.All(c => c.IsConnected));
-			Assert.True (clients.All(c => !string.IsNullOrEmpty (c.Id)));
+			Assert.Equal(count, server.ActiveClients.Count());
+			Assert.True(clients.All(c => c.IsConnected));
+			Assert.True(clients.All(c => !string.IsNullOrEmpty(c.Id)));
 
-			foreach (var client in clients) {
-				client.Dispose ();
+			foreach (var client in clients)
+			{
+				client.Dispose();
 			}
 		}
 
-        [Fact]
-        public async Task when_connecting_twice_with_same_client_then_fails()
-        {
-            var client = await GetClientAsync ();
-            var clientId = GetClientId ();
+		[Fact]
+		public async Task when_connecting_twice_with_same_client_with_disconnecting_then_succeeds()
+		{
+			var client = await GetClientAsync();
+			var clientId = GetClientId();
 
-            var clientDisconnectedEvent = new ManualResetEventSlim ();
+			await client.ConnectAsync(new MqttClientCredentials(clientId));
+			await client.DisconnectAsync();
+			await client.ConnectAsync(new MqttClientCredentials(clientId));
 
-            client.Disconnected += (sender, e) => {
-                if (e.Reason == DisconnectedReason.RemoteDisconnected)
-                {
-                    clientDisconnectedEvent.Set ();
-                }
-            };
+			Assert.Equal(1, server.ActiveConnections);
+			Assert.Equal(1, server.ActiveClients.Count());
 
-            await client.ConnectAsync (new MqttClientCredentials (clientId));
-            await client.ConnectAsync (new MqttClientCredentials (clientId));
+			client.Dispose();
+		}
 
-            var clientRemoteDisconnected = clientDisconnectedEvent.Wait (2000);
+		[Fact]
+		public async Task when_connecting_twice_with_same_client_without_disconnecting_then_fails()
+		{
+			var client = await GetClientAsync();
+			var clientId = GetClientId();
 
-            Assert.True (clientRemoteDisconnected);
-        }
+			await client.ConnectAsync(new MqttClientCredentials(clientId));
 
-        [Fact]
-        public async Task when_connecting_client_with_invalid_id_then_fails()
-        {
-            var client = await GetClientAsync ();
-            var clientId = "#invalid*client-id";
+			var ex = Assert.Throws<AggregateException>(() => client.ConnectAsync(new MqttClientCredentials(clientId)).Wait());
 
-            var ex = Assert.Throws<AggregateException> (() => client.ConnectAsync (new MqttClientCredentials (clientId)).Wait ());
+			Assert.NotNull(ex);
+			Assert.NotNull(ex.InnerException);
+			Assert.True(ex.InnerException is MqttClientException);
+		}
 
-            Assert.NotNull (ex);
-            Assert.NotNull (ex.InnerException);
-            Assert.True (ex.InnerException is MqttClientException);
-            Assert.NotNull (ex.InnerException.InnerException);
-            Assert.True (ex.InnerException.InnerException is MqttException);
-        }
+		[Fact]
+		public async Task when_connecting_client_with_invalid_id_then_fails()
+		{
+			var client = await GetClientAsync();
+			var clientId = "#invalid*client-id";
 
-        [Fact]
-        public async Task when_connecting_client_with_empty_id_then_fails()
-        {
-            var client = await GetClientAsync ();
-            var clientId = string.Empty;
+			var ex = Assert.Throws<AggregateException>(() => client.ConnectAsync(new MqttClientCredentials(clientId)).Wait());
 
-            var ex = Assert.Throws<AggregateException> (() => client.ConnectAsync (new MqttClientCredentials (clientId)).Wait ());
+			Assert.NotNull(ex);
+			Assert.NotNull(ex.InnerException);
+			Assert.True(ex.InnerException is MqttClientException);
+			Assert.NotNull(ex.InnerException.InnerException);
+			Assert.True(ex.InnerException.InnerException is MqttException);
+		}
 
-            Assert.NotNull (ex);
-            Assert.NotNull (ex.InnerException);
-            Assert.True (ex.InnerException is MqttClientException);
-            Assert.NotNull (ex.InnerException.InnerException);
-            Assert.True (ex.InnerException.InnerException is ArgumentNullException);
+		[Fact]
+		public async Task when_connecting_client_with_empty_id_then_fails()
+		{
+			var client = await GetClientAsync();
+			var clientId = string.Empty;
 
-        }
+			var ex = Assert.Throws<AggregateException>(() => client.ConnectAsync(new MqttClientCredentials(clientId)).Wait());
 
-        [Fact]
-        public async Task when_server_doesnt_receive_connect_then_disconnects_channel()
-        {
-            var client = await GetClientAsync ();
-            var clientDisconnectedEvent = new ManualResetEventSlim ();
+			Assert.NotNull(ex);
+			Assert.NotNull(ex.InnerException);
+			Assert.True(ex.InnerException is MqttClientException);
+			Assert.NotNull(ex.InnerException.InnerException);
+			Assert.True(ex.InnerException.InnerException is ArgumentNullException);
 
-            client.Disconnected += (sender, e) => {
-                if (e.Reason == DisconnectedReason.RemoteDisconnected)
-                {
-                    clientDisconnectedEvent.Set ();
-                }
-            };
+		}
 
-            var clientRemoteDisconnected = clientDisconnectedEvent.Wait (2500);
-
-            Assert.True (clientRemoteDisconnected);
-        }
-
-        [Fact]
+		[Fact]
 		public async Task when_disconnect_clients_then_succeeds()
 		{
-			var count = GetTestLoad ();
-			var clients = new List<IMqttClient> ();
-			var connectTasks = new List<Task> ();
+			var count = GetTestLoad();
+			var clients = new List<IMqttClient>();
+			var connectTasks = new List<Task>();
 
-			for (var i = 1; i <= count; i++) {
-				var client = await GetClientAsync ();
+			for (var i = 1; i <= count; i++)
+			{
+				var client = await GetClientAsync();
 
-				connectTasks.Add(client.ConnectAsync (new MqttClientCredentials (GetClientId ())));
-				clients.Add (client);
+				connectTasks.Add(client.ConnectAsync(new MqttClientCredentials(GetClientId())));
+				clients.Add(client);
 			}
 
-			await Task.WhenAll (connectTasks);
+			await Task.WhenAll(connectTasks);
 
-            var initialConnectedClients = server.ActiveClients.Count ();
-			var disconnectTasks = new List<Task> ();
+			var initialConnectedClients = server.ActiveClients.Count();
+			var disconnectTasks = new List<Task>();
 
-			foreach (var client in clients) {
-				disconnectTasks.Add(client.DisconnectAsync ());
+			foreach (var client in clients)
+			{
+				disconnectTasks.Add(client.DisconnectAsync());
 			}
 
-			await Task.WhenAll (disconnectTasks);
+			await Task.WhenAll(disconnectTasks);
 
-			var disconnectedSignal = new ManualResetEventSlim (initialState: false);
+			var disconnectedSignal = new ManualResetEventSlim(initialState: false);
 
-			while (!disconnectedSignal.IsSet) {
-				if (server.ActiveClients.Count () == 0 && clients.All(c => !c.IsConnected)) {
-					disconnectedSignal.Set ();
+			while (!disconnectedSignal.IsSet)
+			{
+				if (server.ActiveClients.Count() == 0 && clients.All(c => !c.IsConnected))
+				{
+					disconnectedSignal.Set();
 				}
 			}
 
-            Assert.Equal (clients.Count, initialConnectedClients);
-			Assert.Equal (0, server.ActiveClients.Count ());
-			Assert.True (clients.All(c => !c.IsConnected));
-			Assert.True (clients.All(c => string.IsNullOrEmpty (c.Id)));
+			Assert.Equal(clients.Count, initialConnectedClients);
+			Assert.Equal(0, server.ActiveClients.Count());
+			Assert.True(clients.All(c => !c.IsConnected));
+			Assert.True(clients.All(c => string.IsNullOrEmpty(c.Id)));
 
-			foreach (var client in clients) {
-				client.Dispose ();
+			foreach (var client in clients)
+			{
+				client.Dispose();
 			}
 		}
 
 		[Fact]
 		public async Task when_disconnect_client_then_server_decrease_active_client_list()
 		{
-			var client = await GetClientAsync ();
+			var client = await GetClientAsync();
 
-			await client.ConnectAsync (new MqttClientCredentials (GetClientId ()))
+			await client.ConnectAsync(new MqttClientCredentials(GetClientId()))
 				.ConfigureAwait(continueOnCapturedContext: false);
 
 			var clientId = client.Id;
-			var existClientAfterConnect = server.ActiveClients.Any (c => c == clientId);
+			var existClientAfterConnect = server.ActiveClients.Any(c => c == clientId);
 
-			await client.DisconnectAsync ()
+			await client.DisconnectAsync()
 				.ConfigureAwait(continueOnCapturedContext: false);
 
-			var clientClosed = new ManualResetEventSlim ();
+			var clientClosed = new ManualResetEventSlim();
 
-			var subscription = Observable.Create<bool> (observer => {
+			var subscription = Observable.Create<bool>(observer =>
+			{
 				var timer = new System.Timers.Timer();
 
 				timer.Interval = 200;
-				timer.Elapsed += (sender, args) => {
-					if (server.ActiveClients.Any (c => c == clientId)) {
-						observer.OnNext (false);
-					} else {
-						observer.OnNext (true);
-						clientClosed.Set ();
-						observer.OnCompleted ();
+				timer.Elapsed += (sender, args) =>
+				{
+					if (server.ActiveClients.Any(c => c == clientId))
+					{
+						observer.OnNext(false);
+					}
+					else
+					{
+						observer.OnNext(true);
+						clientClosed.Set();
+						observer.OnCompleted();
 					}
 				};
 				timer.Start();
 
-				return () => {
+				return () =>
+				{
 					timer.Dispose();
 				};
 			})
-			.Subscribe (
+			.Subscribe(
 				_ => { },
-				ex => { Console.WriteLine (string.Format ("Error: {0}", ex.Message)); });
+				ex => { Console.WriteLine(string.Format("Error: {0}", ex.Message)); });
 
-			var clientDisconnected = clientClosed.Wait (2000);
+			var clientDisconnected = clientClosed.Wait(2000);
 
-			Assert.True (existClientAfterConnect);
-			Assert.True (clientDisconnected);
-			Assert.False (server.ActiveClients.Any (c => c == clientId));
+			Assert.True(existClientAfterConnect);
+			Assert.True(clientDisconnected);
+			Assert.False(server.ActiveClients.Any(c => c == clientId));
 
-			client.Dispose ();
+			client.Dispose();
 		}
 
 		[Fact]
 		public async Task when_client_disconnects_by_protocol_then_will_message_is_not_sent()
 		{
-			var client1 = await GetClientAsync ();
+			var client1 = await GetClientAsync();
 			var client2 = await GetClientAsync();
-            var client3 = await GetClientAsync();
+			var client3 = await GetClientAsync();
 
-            var topic = Guid.NewGuid ().ToString ();
+			var topic = Guid.NewGuid().ToString();
 			var qos = MqttQualityOfService.ExactlyOnce;
 			var retain = true;
 			var message = "Client 1 has been disconnected unexpectedly";
 			var will = new MqttLastWill(topic, qos, retain, message);
 
-			await client1.ConnectAsync (new MqttClientCredentials (GetClientId ()), will);
-			await client2.ConnectAsync (new MqttClientCredentials (GetClientId ()));
-			await client3.ConnectAsync (new MqttClientCredentials (GetClientId ()));
+			await client1.ConnectAsync(new MqttClientCredentials(GetClientId()), will);
+			await client2.ConnectAsync(new MqttClientCredentials(GetClientId()));
+			await client3.ConnectAsync(new MqttClientCredentials(GetClientId()));
 
 			await client2.SubscribeAsync(topic, MqttQualityOfService.AtMostOnce);
 			await client3.SubscribeAsync(topic, MqttQualityOfService.AtLeastOnce);
 
-			var willReceivedSignal = new ManualResetEventSlim (initialState: false);
+			var willReceivedSignal = new ManualResetEventSlim(initialState: false);
 
-			client2.MessageStream.Subscribe (m => {
-				if (m.Topic == topic) {
-					willReceivedSignal.Set ();
+			client2.MessageStream.Subscribe(m =>
+			{
+				if (m.Topic == topic)
+				{
+					willReceivedSignal.Set();
 				}
 			});
-			client3.MessageStream.Subscribe (m => {
-				if (m.Topic == topic) {
-					willReceivedSignal.Set ();
+			client3.MessageStream.Subscribe(m =>
+			{
+				if (m.Topic == topic)
+				{
+					willReceivedSignal.Set();
 				}
 			});
 
-			await client1.DisconnectAsync ();
+			await client1.DisconnectAsync();
 
-			var willReceived = willReceivedSignal.Wait (2000);
+			var willReceived = willReceivedSignal.Wait(2000);
 
-			Assert.False (willReceived);
+			Assert.False(willReceived);
 
-			client1.Dispose ();
-			client2.Dispose ();
-			client3.Dispose ();
+			client1.Dispose();
+			client2.Dispose();
+			client3.Dispose();
 		}
-		
+
 		[Fact]
 		public async Task when_client_disconnects_unexpectedly_then_will_message_is_sent()
 		{
 			var client1 = await GetClientAsync();
-            var client2 = await GetClientAsync();
-            var client3 = await GetClientAsync();
+			var client2 = await GetClientAsync();
+			var client3 = await GetClientAsync();
 
-            var topic = Guid.NewGuid ().ToString ();
+			var topic = Guid.NewGuid().ToString();
 			var qos = MqttQualityOfService.ExactlyOnce;
 			var retain = true;
 			var message = "Client 1 has been disconnected unexpectedly";
 			var will = new MqttLastWill(topic, qos, retain, message);
 
-			await client1.ConnectAsync (new MqttClientCredentials (GetClientId ()), will);
-			await client2.ConnectAsync (new MqttClientCredentials (GetClientId ()));
-			await client3.ConnectAsync (new MqttClientCredentials (GetClientId ()));
+			await client1.ConnectAsync(new MqttClientCredentials(GetClientId()), will);
+			await client2.ConnectAsync(new MqttClientCredentials(GetClientId()));
+			await client3.ConnectAsync(new MqttClientCredentials(GetClientId()));
 
 			await client2.SubscribeAsync(topic, MqttQualityOfService.AtMostOnce);
 			await client3.SubscribeAsync(topic, MqttQualityOfService.AtLeastOnce);
 
-			var willReceivedSignal = new ManualResetEventSlim (initialState: false);
-			var willMessage = default (MqttApplicationMessage);
+			var willReceivedSignal = new ManualResetEventSlim(initialState: false);
+			var willMessage = default(MqttApplicationMessage);
 
-			client2.MessageStream.Subscribe (m => {
-				if (m.Topic == topic) {
+			client2.MessageStream.Subscribe(m =>
+			{
+				if (m.Topic == topic)
+				{
 					willMessage = m;
-					willReceivedSignal.Set ();
+					willReceivedSignal.Set();
 				}
 			});
-			client3.MessageStream.Subscribe (m => {
-				if (m.Topic == topic) {
+			client3.MessageStream.Subscribe(m =>
+			{
+				if (m.Topic == topic)
+				{
 					willMessage = m;
-					willReceivedSignal.Set ();
+					willReceivedSignal.Set();
 				}
 			});
 
-            //Forces socket disconnection without using protocol Disconnect (Disconnect or Dispose Client method)
-            (client1 as MqttClientImpl).Channel.Dispose ();
+			//Forces socket disconnection without using protocol Disconnect (Disconnect or Dispose Client method)
+			(client1 as MqttClientImpl).Channel.Dispose();
 
-			var willReceived = willReceivedSignal.Wait (2000);
+			var willReceived = willReceivedSignal.Wait(2000);
 
-			Assert.True (willReceived);
-			Assert.NotNull (willMessage);
-			Assert.Equal (topic, willMessage.Topic);
-			Assert.Equal (message, Encoding.UTF8.GetString (willMessage.Payload));
+			Assert.True(willReceived);
+			Assert.NotNull(willMessage);
+			Assert.Equal(topic, willMessage.Topic);
+			Assert.Equal(message, Encoding.UTF8.GetString(willMessage.Payload));
 
-			client2.Dispose ();
-			client3.Dispose ();
+			client2.Dispose();
+			client3.Dispose();
 		}
 
-		public void Dispose ()
-		{
-			if (server != null) {
-				server.Stop ();
-			}
-		}
+		public void Dispose() => server?.Dispose();
 	}
 }

--- a/src/Server/Sdk/MqttConnectedClientFactory.cs
+++ b/src/Server/Sdk/MqttConnectedClientFactory.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Net.Mqtt.Sdk.Bindings;
 using System.Net.Mqtt.Sdk.Flows;
-using System.Net.Mqtt.Sdk.Packets;
 using System.Net.Mqtt.Sdk.Storage;
 using System.Reactive.Subjects;
 using System.Threading.Tasks;
@@ -9,51 +8,53 @@ using System.Threading.Tasks;
 namespace System.Net.Mqtt.Sdk
 {
 	class MqttConnectedClientFactory
-    {
-        static readonly ITracer tracer = Tracer.Get<MqttClientFactory>();
+	{
+		static readonly ITracer tracer = Tracer.Get<MqttClientFactory>();
 
-        readonly ISubject<PrivateStream> privateStreamListener;
+		readonly ISubject<PrivateStream> privateStreamListener;
 
-        public MqttConnectedClientFactory (ISubject<PrivateStream> privateStreamListener)
-        {
-            this.privateStreamListener = privateStreamListener;
-        }
+		public MqttConnectedClientFactory(ISubject<PrivateStream> privateStreamListener)
+		{
+			this.privateStreamListener = privateStreamListener;
+		}
 
-        public async Task<IMqttConnectedClient> CreateClientAsync (MqttConfiguration configuration)
-        {
-            try
-            {
-                var binding = new PrivateBinding (privateStreamListener, EndpointIdentifier.Client);
-                var topicEvaluator = new MqttTopicEvaluator (configuration);
-                var innerChannelFactory = binding.GetChannelFactory (IPAddress.Loopback.ToString (), configuration);
-                var channelFactory = new PacketChannelFactory (innerChannelFactory, topicEvaluator, configuration);
-                var packetIdProvider = new PacketIdProvider ();
-                var repositoryProvider = new InMemoryRepositoryProvider ();
-                var flowProvider = new ClientProtocolFlowProvider (topicEvaluator, repositoryProvider, configuration);
-                var packetChannel = await channelFactory
-                    .CreateAsync ()
-                    .ConfigureAwait (continueOnCapturedContext: false);
+		public async Task<IMqttConnectedClient> CreateClientAsync(MqttConfiguration configuration)
+		{
+			try
+			{
+				//Adding this to not break backwards compatibility related to the method signature
+				//Yielding at this point will cause the method to return immediately after it's called,
+				//running the rest of the logic acynchronously
+				await Task.Yield();
 
-                return new MqttConnectedClient (packetChannel, flowProvider, repositoryProvider, packetIdProvider, configuration);
-            }
-            catch (Exception ex)
-            {
-                tracer.Error(ex, Properties.Resources.Client_InitializeError);
+				var binding = new PrivateBinding(privateStreamListener, EndpointIdentifier.Client);
+				var topicEvaluator = new MqttTopicEvaluator(configuration);
+				var innerChannelFactory = binding.GetChannelFactory(IPAddress.Loopback.ToString(), configuration);
+				var channelFactory = new PacketChannelFactory(innerChannelFactory, topicEvaluator, configuration);
+				var packetIdProvider = new PacketIdProvider();
+				var repositoryProvider = new InMemoryRepositoryProvider();
+				var flowProvider = new ClientProtocolFlowProvider(topicEvaluator, repositoryProvider, configuration);
 
-                throw new MqttClientException (Properties.Resources.Client_InitializeError, ex);
-            }
-        }
-    }
+				return new MqttConnectedClient(channelFactory, flowProvider, repositoryProvider, packetIdProvider, configuration);
+			}
+			catch (Exception ex)
+			{
+				tracer.Error(ex, Properties.Resources.Client_InitializeError);
 
-    class MqttConnectedClient : MqttClientImpl, IMqttConnectedClient
-    {
-        internal MqttConnectedClient(IMqttChannel<IPacket> packetChannel,
-            IProtocolFlowProvider flowProvider,
-            IRepositoryProvider repositoryProvider,
-            IPacketIdProvider packetIdProvider,
-            MqttConfiguration configuration)
-            : base(packetChannel, flowProvider, repositoryProvider, packetIdProvider, configuration)
-        {
-        }
-    }
+				throw new MqttClientException(Properties.Resources.Client_InitializeError, ex);
+			}
+		}
+	}
+
+	class MqttConnectedClient : MqttClientImpl, IMqttConnectedClient
+	{
+		internal MqttConnectedClient(IPacketChannelFactory channelFactory,
+			IProtocolFlowProvider flowProvider,
+			IRepositoryProvider repositoryProvider,
+			IPacketIdProvider packetIdProvider,
+			MqttConfiguration configuration)
+			: base(channelFactory, flowProvider, repositoryProvider, packetIdProvider, configuration)
+		{
+		}
+	}
 }


### PR DESCRIPTION
- Previous to this change, the protocol disconnection was also causing the client instance to be disposed, causing following client usage attempts to fail; forcing a new client instantiation.
- This PR allows the client instances to be re used as much as desired, even with different client credentials; fixing some reported issues