### PR TITLE
3 - Added support to accept any payload type in Will messages

### DIFF
--- a/src/Client/MqttLastWill.cs
+++ b/src/Client/MqttLastWill.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Net.Mqtt
+﻿using System.ComponentModel;
+using System.Text;
+using System.Linq;
+
+namespace System.Net.Mqtt
 {
     /// <summary>
     /// Represents the last will message sent by the Server when a Client
@@ -20,18 +24,42 @@
         /// </param>
         /// <param name="retain">Specifies if the message should be retained or not</param>
         /// <param name="message">Content of the will message to publish</param>
+		[Obsolete ("This constructor is obsolete, please use the constructor with the byte[] payload parameter instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		public MqttLastWill (string topic, MqttQualityOfService qualityOfService, bool retain, string message)
 		{
 			Topic = topic;
 			QualityOfService = qualityOfService;
 			Retain = retain;
 			Message = message;
+			Payload = Encoding.UTF8.GetBytes (message);
 		}
 
-        /// <summary>
-        /// Topic where the message will be published
-        /// The Clients needs to subscribe to this topic in order to receive the will messages
-        /// </summary>
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MqttLastWill" /> class,
+		/// specifying the topic to pusblish the last will message to, the Quality of Service (QoS)
+		/// to use, if the message should be sent as a retained message and also the content of the will message
+		/// to publish
+		/// </summary>
+		/// <param name="topic">Topic to publish the last will message to</param>
+		/// <param name="qualityOfService">
+		/// Quality of Service (QoS) to use when publishing the last will message.
+		/// See <see cref="MqttQualityOfService" /> for more details about the QoS meanings
+		/// </param>
+		/// <param name="retain">Specifies if the message should be retained or not</param>
+		/// <param name="payload">Payload of the will message to publish</param>
+		public MqttLastWill (string topic, MqttQualityOfService qualityOfService, bool retain, byte[] payload)
+		{
+			Topic = topic;
+			QualityOfService = qualityOfService;
+			Retain = retain;
+			Payload = payload;
+		}
+
+		/// <summary>
+		/// Topic where the message will be published
+		/// The Clients needs to subscribe to this topic in order to receive the will messages
+		/// </summary>
 		public string Topic { get; }
 
         /// <summary>
@@ -48,22 +76,29 @@
         /// </summary>
 		public bool Retain { get; }
 
-        /// <summary>
-        /// Content of the will message
-        /// </summary>
+		/// <summary>
+		/// Content of the will message
+		/// </summary>
+		[Obsolete ("This property is obsolete, please use the byte[] Payload property instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		public string Message { get; }
 
-        /// <summary>
-        /// Determines whether this instance and another 
-        /// specified <see cref="MqttLastWill" /> have
-        /// the same values
-        /// </summary>
-        /// <param name="other">The <see cref="MqttLastWill" /> to compare to this instance</param>
-        /// <returns>true if the values of the <paramref name="other"/> parameter 
-        /// are the same values of this instance, otherwise returns false.
-        /// If <paramref name="other"/> is null, the method returns false
-        ///</returns>
-        public bool Equals (MqttLastWill other)
+		/// <summary>
+		/// Payload of the will message
+		/// </summary>
+		public byte[] Payload { get; }
+
+		/// <summary>
+		/// Determines whether this instance and another 
+		/// specified <see cref="MqttLastWill" /> have
+		/// the same values
+		/// </summary>
+		/// <param name="other">The <see cref="MqttLastWill" /> to compare to this instance</param>
+		/// <returns>true if the values of the <paramref name="other"/> parameter 
+		/// are the same values of this instance, otherwise returns false.
+		/// If <paramref name="other"/> is null, the method returns false
+		///</returns>
+		public bool Equals (MqttLastWill other)
 		{
 			if (other == null)
 				return false;
@@ -71,7 +106,7 @@
 			return Topic == other.Topic &&
 				QualityOfService == other.QualityOfService &&
 				Retain == other.Retain &&
-				Message == other.Message;
+				Payload.SequenceEqual (other.Payload);
 		}
 
         /// <summary>
@@ -139,7 +174,7 @@
         /// <returns>A 32-bit signed integer hash code</returns>
 		public override int GetHashCode ()
 		{
-			return Topic.GetHashCode () + Message.GetHashCode ();
+			return Topic.GetHashCode () + Payload.GetHashCode ();
 		}
 	}
 }

--- a/src/Client/MqttLastWill.cs
+++ b/src/Client/MqttLastWill.cs
@@ -27,12 +27,9 @@ namespace System.Net.Mqtt
 		[Obsolete ("This constructor is obsolete, please use the constructor with the byte[] payload parameter instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		public MqttLastWill (string topic, MqttQualityOfService qualityOfService, bool retain, string message)
+			: this (topic, qualityOfService, retain, payload: Encoding.UTF8.GetBytes (message))
 		{
-			Topic = topic;
-			QualityOfService = qualityOfService;
-			Retain = retain;
 			Message = message;
-			Payload = Encoding.UTF8.GetBytes (message);
 		}
 
 		/// <summary>

--- a/src/IntegrationTests/ConnectionSpec.cs
+++ b/src/IntegrationTests/ConnectionSpec.cs
@@ -329,7 +329,7 @@ namespace IntegrationTests
 			var qos = MqttQualityOfService.ExactlyOnce;
 			var retain = true;
 			var willMessage = new FooWillMessage { Message = "Client 1 has been disconnected unexpectedly" };
-			var will = new MqttLastWill(topic, qos, retain, FooWillMessage.GetPayload(willMessage));
+			var will = new MqttLastWill(topic, qos, retain, willMessage.GetPayload());
 
 			await client1.ConnectAsync(new MqttClientCredentials(GetClientId()), will);
 			await client2.ConnectAsync(new MqttClientCredentials(GetClientId()));
@@ -377,7 +377,7 @@ namespace IntegrationTests
 			var qos = MqttQualityOfService.ExactlyOnce;
 			var retain = true;
 			var willMessage = new FooWillMessage { Message = "Client 1 has been disconnected unexpectedly" };
-			var willMessagePayload = FooWillMessage.GetPayload(willMessage);
+			var willMessagePayload = willMessage.GetPayload();
 			var will = new MqttLastWill(topic, qos, retain, willMessagePayload);
 
 			await client1.ConnectAsync(new MqttClientCredentials(GetClientId()), will);

--- a/src/IntegrationTests/IntegrationTests.csproj
+++ b/src/IntegrationTests/IntegrationTests.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Tests\FooWillMessage.cs" Link="FooWillMessage.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="System.Configuration" />
   </ItemGroup>
   

--- a/src/Server/Sdk/Flows/ServerPublishReceiverFlow.cs
+++ b/src/Server/Sdk/Flows/ServerPublishReceiverFlow.cs
@@ -45,7 +45,7 @@ namespace System.Net.Mqtt.Sdk.Flows
             {
                 var willPublish = new Publish(will.Will.Topic, will.Will.QualityOfService, will.Will.Retain, duplicated: false)
                 {
-                    Payload = Encoding.UTF8.GetBytes(will.Will.Message)
+                    Payload = will.Will.Payload
                 };
 
                 tracer.Info(Server.Properties.Resources.ServerPublishReceiverFlow_SendingWill, clientId, willPublish.Topic);

--- a/src/Tests/Flows/ConnectFlowSpec.cs
+++ b/src/Tests/Flows/ConnectFlowSpec.cs
@@ -202,7 +202,7 @@ namespace Tests.Flows
 			var connect = new Connect (clientId, cleanSession: true);
 
 			var willMessage = new FooWillMessage { Message = "Foo Will Message" };
-			var will = new MqttLastWill ("foo/bar", MqttQualityOfService.AtLeastOnce, retain: true, payload: FooWillMessage.GetPayload(willMessage));
+			var will = new MqttLastWill ("foo/bar", MqttQualityOfService.AtLeastOnce, retain: true, payload: willMessage.GetPayload());
 
 			connect.Will = will;
 

--- a/src/Tests/Flows/ConnectFlowSpec.cs
+++ b/src/Tests/Flows/ConnectFlowSpec.cs
@@ -201,7 +201,8 @@ namespace Tests.Flows
 			var clientId = Guid.NewGuid ().ToString ();
 			var connect = new Connect (clientId, cleanSession: true);
 
-			var will = new MqttLastWill ("foo/bar", MqttQualityOfService.AtLeastOnce, retain: true, message: "Foo Will Message");
+			var willMessage = new FooWillMessage { Message = "Foo Will Message" };
+			var will = new MqttLastWill ("foo/bar", MqttQualityOfService.AtLeastOnce, retain: true, payload: FooWillMessage.GetPayload(willMessage));
 
 			connect.Will = will;
 

--- a/src/Tests/FooWillMessage.cs
+++ b/src/Tests/FooWillMessage.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace Tests
+{
+	[Serializable]
+	internal class FooWillMessage
+	{
+		public string Message { get; set; }
+
+		public static byte[] GetPayload (FooWillMessage willMessage)
+		{
+			var formatter = new BinaryFormatter ();
+
+			using (var stream = new MemoryStream ()) {
+				formatter.Serialize(stream, willMessage);
+
+				return stream.ToArray();
+			}
+		}
+
+		public static FooWillMessage GetMessage (byte[] willPayload)
+		{
+			var formatter = new BinaryFormatter ();
+
+			using (var stream = new MemoryStream (willPayload)) {
+				return formatter.Deserialize (stream) as FooWillMessage;
+			}
+		}
+	}
+}

--- a/src/Tests/FooWillMessage.cs
+++ b/src/Tests/FooWillMessage.cs
@@ -9,12 +9,12 @@ namespace Tests
 	{
 		public string Message { get; set; }
 
-		public static byte[] GetPayload (FooWillMessage willMessage)
+		public byte[] GetPayload ()
 		{
 			var formatter = new BinaryFormatter ();
 
 			using (var stream = new MemoryStream ()) {
-				formatter.Serialize(stream, willMessage);
+				formatter.Serialize(stream, this);
 
 				return stream.ToArray();
 			}

--- a/src/Tests/Formatters/ConnectFormatterSpec.cs
+++ b/src/Tests/Formatters/ConnectFormatterSpec.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.IO;
-using System.Threading.Tasks;
 using System.Net.Mqtt;
 using System.Net.Mqtt.Sdk.Formatters;
 using System.Net.Mqtt.Sdk.Packets;
+using System.Threading.Tasks;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Tests.Formatters
 {

--- a/src/Tests/MqttLastWillConverter.cs
+++ b/src/Tests/MqttLastWillConverter.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Net.Mqtt;
+using System.Text;
+
+namespace Tests
+{
+	internal class MqttLastWillConverter : JsonConverter
+	{
+		public override bool CanWrite => false;
+
+		public override bool CanConvert (Type objectType) => objectType == typeof (MqttLastWill);
+
+		public override object ReadJson (JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			var jObject = JObject.Load (reader);
+
+			var topic = jObject["topic"].ToObject<string> ();
+			var qos = jObject["qualityOfService"].ToObject<MqttQualityOfService> ();
+			var retain = jObject["retain"].ToObject<bool> ();
+			var message = jObject["message"].ToObject<string> ();
+			var hasMessage = !string.IsNullOrEmpty ((message));
+			var payload = hasMessage ? Encoding.UTF8.GetBytes (message) : jObject["message"].ToObject<byte[]> ();
+
+			return new MqttLastWill (topic, qos, retain, payload);
+		}
+
+		public override void WriteJson (JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/src/Tests/Packet.cs
+++ b/src/Tests/Packet.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
+using System.Net.Mqtt;
 using System.Net.Mqtt.Sdk.Packets;
-using Newtonsoft.Json;
+using System.Text;
 
 namespace Tests
 {
@@ -80,14 +81,22 @@ namespace Tests
 			return Deserialize (text, type);
 		}
 
-		static T Deserialize<T>(string serialized)
+		static T Deserialize<T> (string serialized)
         {
-			return JsonConvert.DeserializeObject<T> (serialized, new StringByteArrayConverter());
+			return JsonConvert.DeserializeObject<T> (serialized, GetConverters (typeof(T)).ToArray ());
         }
 
-		static object Deserialize(string serialized, Type type)
+		static object Deserialize (string serialized, Type type)
         {
-			return JsonConvert.DeserializeObject (serialized, type, new StringByteArrayConverter());
+			return JsonConvert.DeserializeObject (serialized, type, GetConverters (type).ToArray ());
         }
+
+		static IEnumerable<JsonConverter> GetConverters (Type type)
+		{
+			if (type == typeof (Connect))
+				yield return new MqttLastWillConverter ();
+
+			yield return new StringByteArrayConverter ();
+		}
 	}
 }


### PR DESCRIPTION
- Previously we were only accepting a string type as a last will message, making some scenarios very limites
- This PR adds support to pass any type of payload as a byte[], as any other PUBLISH packet would do.
- This add more flexibility and fixes some already known and reported issues