### PR TITLE
4 - Fixed bugs on pending messages sending logic on client re connection

### DIFF
--- a/src/Client/Sdk/MqttClientImpl.cs
+++ b/src/Client/Sdk/MqttClientImpl.cs
@@ -19,8 +19,8 @@ namespace System.Net.Mqtt.Sdk
 		IPacketListener packetListener;
 		IDisposable packetsSubscription;
 
-		readonly ReplaySubject<MqttApplicationMessage> receiver;
-		readonly ReplaySubject<IPacket> sender;
+		readonly Subject<MqttApplicationMessage> receiver;
+		readonly Subject<IPacket> sender;
 		readonly IPacketChannelFactory channelFactory;
 		readonly IProtocolFlowProvider flowProvider;
 		readonly IRepository<ClientSession> sessionRepository;
@@ -34,8 +34,8 @@ namespace System.Net.Mqtt.Sdk
 			IPacketIdProvider packetIdProvider,
 			MqttConfiguration configuration)
 		{
-			receiver = new ReplaySubject<MqttApplicationMessage> (window: TimeSpan.FromSeconds (configuration.WaitTimeoutSecs));
-			sender = new ReplaySubject<IPacket> (window: TimeSpan.FromSeconds (configuration.WaitTimeoutSecs));
+			receiver = new Subject<MqttApplicationMessage> ();
+			sender = new Subject<IPacket> ();
 
 			this.channelFactory = channelFactory;
 			this.flowProvider = flowProvider;

--- a/src/IntegrationTests/Messages/TestMessage.cs
+++ b/src/IntegrationTests/Messages/TestMessage.cs
@@ -5,6 +5,8 @@ namespace IntegrationTests.Messages
 	[Serializable]
 	public class TestMessage
 	{
+		public int Id { get; set; }
+
 		public string Name { get; set; }
 
 		public int Value { get; set; }

--- a/src/IntegrationTests/PublishingSpec.cs
+++ b/src/IntegrationTests/PublishingSpec.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Collections.Generic;
 using System.Net.Mqtt;
 using System.Net.Mqtt.Sdk;
+using System.Reactive.Linq;
 
 namespace IntegrationTests
 {
@@ -31,7 +32,7 @@ namespace IntegrationTests
 			var tasks = new List<Task> ();
 
 			for (var i = 1; i <= count; i++) {
-				var testMessage = GetTestMessage ();
+				var testMessage = GetTestMessage (i);
                 var message = new MqttApplicationMessage (topic, Serializer.Serialize (testMessage));
 
 				tasks.Add (client.PublishAsync (message, MqttQualityOfService.AtMostOnce));
@@ -65,7 +66,7 @@ namespace IntegrationTests
                });
 
             for (var i = 1; i <= count; i++) {
-				var testMessage = GetTestMessage();
+				var testMessage = GetTestMessage(i);
                 var message = new MqttApplicationMessage (topic, Serializer.Serialize (testMessage));
 
 				tasks.Add (client.PublishAsync (message, MqttQualityOfService.AtLeastOnce));
@@ -102,7 +103,7 @@ namespace IntegrationTests
                 });
 
 			for (var i = 1; i <= count; i++) {
-				var testMessage = GetTestMessage();
+				var testMessage = GetTestMessage(i);
                 var message = new MqttApplicationMessage (topic, Serializer.Serialize (testMessage));
 
 				tasks.Add (client.PublishAsync (message, MqttQualityOfService.ExactlyOnce));
@@ -163,7 +164,7 @@ namespace IntegrationTests
 			var tasks = new List<Task> ();
 
 			for (var i = 1; i <= count; i++) {
-				var testMessage = GetTestMessage ();
+				var testMessage = GetTestMessage (i);
                 var message = new MqttApplicationMessage (topic, Serializer.Serialize (testMessage));
 
 				tasks.Add (publisher.PublishAsync (message, MqttQualityOfService.AtMostOnce));
@@ -208,7 +209,7 @@ namespace IntegrationTests
 			var tasks = new List<Task> ();
 
 			for (var i = 1; i <= count; i++) {
-				var testMessage = GetTestMessage ();
+				var testMessage = GetTestMessage (i);
                 var message = new MqttApplicationMessage (topic, Serializer.Serialize (testMessage));
 
 				tasks.Add (publisher.PublishAsync (message, MqttQualityOfService.AtMostOnce));
@@ -375,16 +376,137 @@ namespace IntegrationTests
             client.Dispose();
         }
 
-        public void Dispose ()
+		[Fact]
+		public async Task when_publish_without_clean_session_then_pending_messages_are_sent_when_reconnect()
+		{
+			var client1 = await GetClientAsync();
+			var client1Done = new ManualResetEventSlim();
+			var client1Received = 0;
+
+			var client2 = await GetClientAsync();
+			var client2Id = client2.Id;
+			var client2Done = new ManualResetEventSlim();
+			var client2Received = 0;
+
+			var topic = "topic/foo/bar";
+			var messagesBeforeDisconnect = 3;
+			var messagesAfterReconnect = 2;
+
+			await client1.SubscribeAsync(topic, MqttQualityOfService.AtLeastOnce);
+			await client2.SubscribeAsync(topic, MqttQualityOfService.AtLeastOnce);
+
+			var subscription1 = client1
+				.MessageStream
+				.Where(m => m.Topic == topic)
+				.Subscribe(m => {
+					client1Received++;
+
+					if (client1Received == messagesBeforeDisconnect)
+						client1Done.Set();
+				});
+
+			var subscription2 = client2
+				.MessageStream
+				.Where(m => m.Topic == topic)
+				.Subscribe(m => {
+					client2Received++;
+
+					if (client2Received == messagesBeforeDisconnect)
+						client2Done.Set();
+				});
+
+			for (var i = 1; i <= messagesBeforeDisconnect; i++) {
+				var testMessage = GetTestMessage(i);
+				var message = new MqttApplicationMessage(topic, Serializer.Serialize(testMessage));
+
+				await client1.PublishAsync(message, MqttQualityOfService.AtLeastOnce, retain: false);
+			}
+
+			var completed = WaitHandle.WaitAll(new WaitHandle[] { client1Done.WaitHandle, client2Done.WaitHandle }, TimeSpan.FromSeconds(Configuration.WaitTimeoutSecs));
+
+			Assert.True(completed, $"Messages before disconnect weren't all received. Client 1 received: {client1Received}, Client 2 received: {client2Received}");
+			Assert.Equal(messagesBeforeDisconnect, client1Received);
+			Assert.Equal(messagesBeforeDisconnect, client2Received);
+
+			await client2.DisconnectAsync();
+
+			subscription1.Dispose();
+			client1Received = 0;
+			client1Done.Reset();
+			subscription2.Dispose();
+			client2Received = 0;
+			client2Done.Reset();
+
+			var client1OldMessagesReceived = 0;
+			var client2OldMessagesReceived = 0;
+
+			subscription1 = client1
+				.MessageStream
+				.Where(m => m.Topic == topic)
+				.Subscribe(m => {
+					var testMessage = Serializer.Deserialize<TestMessage>(m.Payload);
+
+					if (testMessage.Id > messagesBeforeDisconnect)
+						client1Received++;
+					else
+						client1OldMessagesReceived++;
+
+					if (client1Received == messagesAfterReconnect)
+						client1Done.Set();
+				});
+
+			subscription2 = client2
+				.MessageStream
+				.Where(m => m.Topic == topic)
+				.Subscribe(m => {
+					var testMessage = Serializer.Deserialize<TestMessage>(m.Payload);
+
+					if (testMessage.Id > messagesBeforeDisconnect)
+						client2Received++;
+					else
+						client2OldMessagesReceived++;
+
+					if (client2Received == messagesAfterReconnect)
+						client2Done.Set();
+				});
+
+			for (var i = messagesBeforeDisconnect + 1; i <= messagesBeforeDisconnect + messagesAfterReconnect; i++) {
+				var testMessage = GetTestMessage(i);
+				var message = new MqttApplicationMessage(topic, Serializer.Serialize(testMessage));
+
+				await client1.PublishAsync(message, MqttQualityOfService.AtLeastOnce, retain: false);
+			}
+
+			await client2.ConnectAsync(new MqttClientCredentials(client2Id), cleanSession: false);
+
+			completed = WaitHandle.WaitAll(new WaitHandle[] { client1Done.WaitHandle, client2Done.WaitHandle }, TimeSpan.FromSeconds(Configuration.WaitTimeoutSecs));
+
+			Assert.True(completed, $"Messages after re connect weren't all received. Client 1 received: {client1Received}, Client 2 received: {client2Received}");
+			Assert.Equal(messagesAfterReconnect, client1Received);
+			Assert.Equal(messagesAfterReconnect, client2Received);
+			Assert.Equal(0, client1OldMessagesReceived);
+			Assert.Equal(0, client2OldMessagesReceived);
+
+			await client1.UnsubscribeAsync(topic)
+				.ConfigureAwait(continueOnCapturedContext: false);
+			await client2.UnsubscribeAsync(topic)
+				.ConfigureAwait(continueOnCapturedContext: false);
+
+			client1.Dispose();
+			client2.Dispose();
+		}
+
+		public void Dispose ()
 		{
 			if (server != null) {
 				server.Stop ();
 			}
 		}
 
-		TestMessage GetTestMessage()
+		TestMessage GetTestMessage(int id)
 		{
 			return new TestMessage {
+				Id = id,
 				Name = string.Concat("Message ", Guid.NewGuid().ToString().Substring(0, 4)),
 				Value = new Random().Next()
 			};

--- a/src/Server/Sdk/Flows/ServerConnectFlow.cs
+++ b/src/Server/Sdk/Flows/ServerConnectFlow.cs
@@ -78,8 +78,11 @@ namespace System.Net.Mqtt.Sdk.Flows
 		async Task SendPendingMessagesAsync (ClientSession session, IMqttChannel<IPacket> channel)
 		{
 			foreach (var pendingMessage in session.GetPendingMessages ()) {
-				var publish = new Publish(pendingMessage.Topic, pendingMessage.QualityOfService,
-					pendingMessage.Retain, pendingMessage.Duplicated, pendingMessage.PacketId);
+				var publish = new Publish (pendingMessage.Topic, pendingMessage.QualityOfService,
+					pendingMessage.Retain, pendingMessage.Duplicated, pendingMessage.PacketId)
+				{
+					Payload = pendingMessage.Payload
+				};
 
 				if (pendingMessage.Status == PendingMessageStatus.PendingToSend) {
 					session.RemovePendingMessage (pendingMessage);


### PR DESCRIPTION
- There was a bug that was making the re sent messages after re connection with clean session false, to be sent with null payload
- Also, after re connecting with clean session false the pending messages were re sent together with other messages already sent, causing overhead and also a behavior not algined with the protocol specification
- This PR fixes the mentioned issues, already reported in this repo