### PR TITLE
6 - Implemented zero bytes client id support according to the spec

### DIFF
--- a/src/Client/IMqttClient.cs
+++ b/src/Client/IMqttClient.cs
@@ -74,12 +74,16 @@ namespace System.Net.Mqtt
 		/// The last will message to send from the Server when an unexpected Client disconnection occurrs. 
 		/// See <see cref="MqttLastWill" /> for more details about the will message structure
 		/// </param>
+		/// /// <returns>
+		/// Returns the state of the client session created as part of the connection
+		/// See <see cref="SessionState" /> for more details about the session state values
+		/// </returns>
 		/// <exception cref="MqttClientException">MqttClientException</exception>
 		/// <remarks>
 		/// See <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html#_Toc442180841">MQTT Connect</a>
 		/// for more details about the protocol connection
 		/// </remarks>
-		Task<IConnectAck> ConnectAsync (MqttLastWill will = null);
+		Task<SessionState> ConnectAsync (MqttLastWill will = null);
 
 		/// <summary>
 		/// Represents the protocol subscription, which consists of sending a SUBSCRIBE packet

--- a/src/Client/IMqttClient.cs
+++ b/src/Client/IMqttClient.cs
@@ -64,24 +64,41 @@ namespace System.Net.Mqtt
 		/// </remarks>
 		Task<SessionState> ConnectAsync (MqttClientCredentials credentials, MqttLastWill will = null, bool cleanSession = false);
 
-        /// <summary>
-        /// Represents the protocol subscription, which consists of sending a SUBSCRIBE packet
-        /// and awaiting the corresponding SUBACK packet from the Server
-        /// </summary>
-        /// <param name="topicFilter">
-        /// The topic to subscribe for incoming application messages. 
-        /// Every message sent by the Server that matches a subscribed topic, will go to the <see cref="MessageStream"/> 
-        /// </param>
-        /// <param name="qos">
-        /// The maximum Quality Of Service (QoS) that the Server should maintain when publishing application messages for the subscribed topic to the Client
-        /// This QoS is maximum because it depends on the QoS supported by the Server. 
-        /// See <see cref="MqttQualityOfService" /> for more details about the QoS values
-        /// </param>
-        /// <exception cref="MqttClientException">MqttClientException</exception>
-        /// <remarks>
-        /// See <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html#_Toc442180876">MQTT Subscribe</a>
-        /// for more details about the protocol subscription
-        /// </remarks>
+		/// <summary>
+		/// Represents the protocol connection, which consists of sending a CONNECT packet
+		/// and awaiting the corresponding CONNACK packet from the Server.
+		/// This overload allows to connect without specifying a client id, in which case a random id will be generated
+		/// according to the specification of the protocol.
+		/// </summary>
+		/// <param name="will">
+		/// The last will message to send from the Server when an unexpected Client disconnection occurrs. 
+		/// See <see cref="MqttLastWill" /> for more details about the will message structure
+		/// </param>
+		/// <exception cref="MqttClientException">MqttClientException</exception>
+		/// <remarks>
+		/// See <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html#_Toc442180841">MQTT Connect</a>
+		/// for more details about the protocol connection
+		/// </remarks>
+		Task<IConnectAck> ConnectAsync (MqttLastWill will = null);
+
+		/// <summary>
+		/// Represents the protocol subscription, which consists of sending a SUBSCRIBE packet
+		/// and awaiting the corresponding SUBACK packet from the Server
+		/// </summary>
+		/// <param name="topicFilter">
+		/// The topic to subscribe for incoming application messages. 
+		/// Every message sent by the Server that matches a subscribed topic, will go to the <see cref="MessageStream"/> 
+		/// </param>
+		/// <param name="qos">
+		/// The maximum Quality Of Service (QoS) that the Server should maintain when publishing application messages for the subscribed topic to the Client
+		/// This QoS is maximum because it depends on the QoS supported by the Server. 
+		/// See <see cref="MqttQualityOfService" /> for more details about the QoS values
+		/// </param>
+		/// <exception cref="MqttClientException">MqttClientException</exception>
+		/// <remarks>
+		/// See <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html#_Toc442180876">MQTT Subscribe</a>
+		/// for more details about the protocol subscription
+		/// </remarks>
 		Task SubscribeAsync (string topicFilter, MqttQualityOfService qos);
 
         /// <summary>

--- a/src/Client/MqttClient.cs
+++ b/src/Client/MqttClient.cs
@@ -14,21 +14,33 @@ namespace System.Net.Mqtt
 		/// <paramref name="hostAddress"/> server via TCP using the specified 
 		/// MQTT configuration to customize the protocol parameters.
 		/// </summary>
-		public static Task<IMqttClient> CreateAsync(string hostAddress, MqttConfiguration configuration) =>
-			new MqttClientFactory(hostAddress).CreateClientAsync(configuration);
+		public static Task<IMqttClient> CreateAsync (string hostAddress, MqttConfiguration configuration) =>
+			new MqttClientFactory (hostAddress).CreateClientAsync (configuration);
 
 		/// <summary>
 		/// Creates an <see cref="IMqttClient"/> and connects it to the destination 
 		/// <paramref name="hostAddress"/> server via TCP using the specified port.
 		/// </summary>
-		public static Task<IMqttClient> CreateAsync(string hostAddress, int port) => 
-			new MqttClientFactory(hostAddress).CreateClientAsync(new MqttConfiguration { Port = port });
+		public static Task<IMqttClient> CreateAsync (string hostAddress, int port) => 
+			new MqttClientFactory (hostAddress).CreateClientAsync (new MqttConfiguration { Port = port });
 
 		/// <summary>
 		/// Creates an <see cref="IMqttClient"/> and connects it to the destination 
 		/// <paramref name="hostAddress"/> server via TCP using the protocol defaults.
 		/// </summary>
-		public static Task<IMqttClient> CreateAsync(string hostAddress) =>
-			new MqttClientFactory(hostAddress).CreateClientAsync(new MqttConfiguration());
+		public static Task<IMqttClient> CreateAsync (string hostAddress) =>
+			new MqttClientFactory (hostAddress).CreateClientAsync (new MqttConfiguration ());
+
+		internal static string GetPrivateClientId () =>
+			string.Format (
+				"private{0}",
+				Guid.NewGuid ().ToString ().Replace ("-", string.Empty).Substring (0, 10)
+			);
+
+		internal static string GetAnonymousClientId () =>
+			string.Format (
+				"anonymous{0}",
+				Guid.NewGuid ().ToString ().Replace ("-", string.Empty).Substring (0, 10)
+			);
 	}
 }

--- a/src/Client/MqttClientCredentials.cs
+++ b/src/Client/MqttClientCredentials.cs
@@ -5,36 +5,41 @@
     /// </summary>
 	public class MqttClientCredentials
 	{
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MqttClientCredentials" /> class 
-        /// specifying the id of client to connect
-        /// </summary>
-        /// <param name="clientId">Id of the client to connect</param>
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MqttClientCredentials" /> class 
+		/// specifying the id of client to connect
+		/// </summary>
+		/// <param name="clientId">Id of the client to connect</param>
 		public MqttClientCredentials (string clientId)
+			: this (clientId, userName: string.Empty, password: string.Empty)
 		{
-			ClientId = clientId;
 		}
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MqttClientCredentials" /> class 
-        /// specifying the id of client to connect, and the username and password
-        /// for authentication
-        /// </summary>
-        /// <param name="clientId">Id of the client to connect</param>
-        /// <param name="userName">Username for authentication</param>
-        /// /// <param name="password">Password for authentication</param>
-        public MqttClientCredentials (string clientId, string userName, string password)
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MqttClientCredentials" /> class 
+		/// specifying the id of client to connect, the username and password
+		/// for authentication
+		/// </summary>
+		/// <param name="clientId">Id of the client to connect</param>
+		/// <param name="userName">Username for authentication</param>
+		/// /// <param name="password">Password for authentication</param>
+		public MqttClientCredentials (string clientId, string userName, string password)
 		{
 			ClientId = clientId;
 			UserName = userName;
 			Password = password;
         }
 
-        /// <summary>
-        /// Id of the client to connect
-        /// The Client Id must contain only the characters 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ
-        /// and have a maximum of 23 encoded bytes
-        /// </summary>
+		internal MqttClientCredentials () : this (clientId: string.Empty)
+		{
+		}
+
+		/// <summary>
+		/// Id of the client to connect
+		/// The Client Id must contain only the characters 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ
+		/// and have a maximum of 23 encoded bytes. 
+		/// It can also be null or empty, in which case the Broker will generate and assign it
+		/// </summary>
 		public string ClientId { get; }
 
         /// <summary>

--- a/src/Client/Properties/Resources.Designer.cs
+++ b/src/Client/Properties/Resources.Designer.cs
@@ -97,6 +97,15 @@ namespace System.Net.Mqtt.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Anonymous clients must set the &quot;cleanSession&quot; parameter to true in order to perform the protocol connection.
+        /// </summary>
+        internal static string Client_AnonymousClientWithoutCleanSession {
+            get {
+                return ResourceManager.GetString("Client_AnonymousClientWithoutCleanSession", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Client {0} - Cleaned old session.
         /// </summary>
         internal static string Client_CleanedOldSession {
@@ -349,20 +358,20 @@ namespace System.Net.Mqtt.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Client Ids with zero bytes length requires the Clean Session value to be 1 (true).
+        /// </summary>
+        internal static string ConnectFormatter_ClientIdEmptyRequiresCleanSession {
+            get {
+                return ResourceManager.GetString("ConnectFormatter_ClientIdEmptyRequiresCleanSession", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Client Id cannot exceed 23 bytes.
         /// </summary>
         internal static string ConnectFormatter_ClientIdMaxLengthExceeded {
             get {
                 return ResourceManager.GetString("ConnectFormatter_ClientIdMaxLengthExceeded", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Client Id value is required and cannot be null or empty.
-        /// </summary>
-        internal static string ConnectFormatter_ClientIdRequired {
-            get {
-                return ResourceManager.GetString("ConnectFormatter_ClientIdRequired", resourceCulture);
             }
         }
         

--- a/src/Client/Properties/Resources.resx
+++ b/src/Client/Properties/Resources.resx
@@ -237,8 +237,8 @@
   <data name="ConnectFormatter_ClientIdMaxLengthExceeded" xml:space="preserve">
     <value>Client Id cannot exceed 23 bytes</value>
   </data>
-  <data name="ConnectFormatter_ClientIdRequired" xml:space="preserve">
-    <value>Client Id value is required and cannot be null or empty</value>
+  <data name="ConnectFormatter_ClientIdEmptyRequiresCleanSession" xml:space="preserve">
+    <value>Client Ids with zero bytes length requires the Clean Session value to be 1 (true)</value>
   </data>
   <data name="ConnectFormatter_InvalidClientIdFormat" xml:space="preserve">
     <value>{0} is an invalid ClientId. It must contain only numbers and letters</value>
@@ -341,5 +341,8 @@
   </data>
   <data name="Client_AlreadyDisconnected" xml:space="preserve">
     <value>The protocol disconnection cannot be performed because the client is already disconnected</value>
+  </data>
+  <data name="Client_AnonymousClientWithoutCleanSession" xml:space="preserve">
+    <value>Anonymous clients must set the "cleanSession" parameter to true in order to perform the protocol connection</value>
   </data>
 </root>

--- a/src/Client/Sdk/MqttClientImpl.cs
+++ b/src/Client/Sdk/MqttClientImpl.cs
@@ -354,7 +354,7 @@ namespace System.Net.Mqtt.Sdk
 
 		void OpenClientSession (bool cleanSession)
 		{
-			var session = string.IsNullOrEmpty (Id) ? default (ClientSession) : sessionRepository.Get (Id);
+			var session = string.IsNullOrEmpty (Id) ? default (ClientSession) : sessionRepository.Read (Id);
 			var sessionPresent = cleanSession ? false : session != null;
 
 			if (cleanSession && session != null) {
@@ -375,7 +375,7 @@ namespace System.Net.Mqtt.Sdk
 
 		void CloseClientSession ()
 		{
-			var session = string.IsNullOrEmpty (Id) ? default (ClientSession) : sessionRepository.Get (Id);
+			var session = string.IsNullOrEmpty (Id) ? default (ClientSession) : sessionRepository.Read (Id);
 
 			if (session == null) {
 				return;

--- a/src/Client/Sdk/MqttEncoder.cs
+++ b/src/Client/Sdk/MqttEncoder.cs
@@ -9,12 +9,8 @@ namespace System.Net.Mqtt.Sdk
 
         internal byte[] EncodeString (string text)
 		{
-			if (string.IsNullOrEmpty (text)) {
-				return new byte[] { };
-			}
-
 			var bytes = new List<byte> ();
-			var textBytes = Encoding.UTF8.GetBytes (text);
+			var textBytes = Encoding.UTF8.GetBytes (text ?? string.Empty);
 
 			if (textBytes.Length > MqttProtocol.MaxIntegerLength) {
 				throw new MqttException  (Properties.Resources.ProtocolEncoding_StringMaxLengthExceeded);

--- a/src/IntegrationTests/ConnectionSpec.cs
+++ b/src/IntegrationTests/ConnectionSpec.cs
@@ -204,19 +204,40 @@ namespace IntegrationTests
 		}
 
 		[Fact]
-		public async Task when_connecting_client_with_empty_id_then_fails()
+		public async Task when_connecting_client_with_empty_id_then_succeeds()
+		{
+			var client = await GetClientAsync();
+
+			await client.ConnectAsync();
+
+			Assert.True(client.IsConnected);
+			Assert.False(string.IsNullOrEmpty(client.Id));
+			Assert.True(client.Id.StartsWith("anonymous"));
+		}
+
+		[Fact]
+		public async Task when_connecting_client_with_empty_id_and_clean_session_true_then_succeeds()
+		{
+			var client = await GetClientAsync();
+
+			await client.ConnectAsync(new MqttClientCredentials(clientId: null), cleanSession: true);
+
+			Assert.True(client.IsConnected);
+			Assert.False(string.IsNullOrEmpty(client.Id));
+			Assert.True(client.Id.StartsWith("anonymous"));
+		}
+
+		[Fact]
+		public async Task when_connecting_client_with_empty_id_and_clean_session_false_then_fails()
 		{
 			var client = await GetClientAsync();
 			var clientId = string.Empty;
 
-			var ex = Assert.Throws<AggregateException>(() => client.ConnectAsync(new MqttClientCredentials(clientId)).Wait());
+			var ex = Assert.Throws<AggregateException>(() => client.ConnectAsync(new MqttClientCredentials(clientId), cleanSession: false).Wait());
 
 			Assert.NotNull(ex);
 			Assert.NotNull(ex.InnerException);
 			Assert.True(ex.InnerException is MqttClientException);
-			Assert.NotNull(ex.InnerException.InnerException);
-			Assert.True(ex.InnerException.InnerException is ArgumentNullException);
-
 		}
 
 		[Fact]

--- a/src/Server/Sdk/MqttServerImpl.cs
+++ b/src/Server/Sdk/MqttServerImpl.cs
@@ -175,10 +175,7 @@ namespace System.Net.Mqtt.Sdk
 
         string GetPrivateClientId ()
         {
-            var clientId = string.Format (
-                "private{0}", 
-                Guid.NewGuid ().ToString ().Replace ("-", string.Empty).Substring (0, 10)
-            );
+			var clientId = MqttClient.GetPrivateClientId ();
 
             if (connectionProvider.PrivateClients.Contains (clientId)) {
                 return GetPrivateClientId ();

--- a/src/Tests/Files/Binaries/Connect_Invalid_ClientIdEmptyAndNoCleanSession.packet
+++ b/src/Tests/Files/Binaries/Connect_Invalid_ClientIdEmptyAndNoCleanSession.packet
@@ -4,7 +4,7 @@
 00000100 #Protocol Name LSB (4)
 "MQTT" #UTF8-encoded
 00000100 #Protocol Level (4)
-00000010 #Connect Flags: User Name (0), Password (0), Will Retain (0), Will QoS (00), Will Flag (0), Clean Session (1), Reserved (0)
+00000000 #Connect Flags: User Name (0), Password (0), Will Retain (0), Will QoS (00), Will Flag (0), Clean Session (0), Reserved (0)
 00000000 #Keep Alive MSB (0)
 00001010 #Keep Alive LSB (5)
 00000000 #ClientId MSB(0)

--- a/src/Tests/Files/Packets/Connect_Invalid_ClientIdEmpty.json
+++ b/src/Tests/Files/Packets/Connect_Invalid_ClientIdEmpty.json
@@ -1,3 +1,0 @@
-﻿{
-    "cleanSession": "true"
-}

--- a/src/Tests/Formatters/ConnectFormatterSpec.cs
+++ b/src/Tests/Formatters/ConnectFormatterSpec.cs
@@ -49,7 +49,7 @@ namespace Tests.Formatters
 		}
 
 		[Theory]
-		[InlineData("Files/Binaries/Connect_Invalid_ClientIdEmpty.packet")]
+		[InlineData("Files/Binaries/Connect_Invalid_ClientIdEmptyAndNoCleanSession.packet")]
 		[InlineData("Files/Binaries/Connect_Invalid_ClientIdBadFormat.packet")]
         public void when_reading_invalid_client_id_in_connect_packet_then_fails(string packetPath)
 		{
@@ -83,7 +83,6 @@ namespace Tests.Formatters
 
 		[Theory]
 		[InlineData("Files/Packets/Connect_Invalid_UserNamePassword.json")]
-		[InlineData("Files/Packets/Connect_Invalid_ClientIdEmpty.json")]
 		[InlineData("Files/Packets/Connect_Invalid_ClientIdBadFormat.json")]
 		[InlineData("Files/Packets/Connect_Invalid_ClientIdInvalidLength.json")]
 		public void when_writing_invalid_connect_packet_then_fails(string jsonPath)


### PR DESCRIPTION
Based on the protocol spec, both Client and Server may support anonymous clients, which is basically clients with zero bytes in the client id section of the packet.

The Server may allow zero bytes client ids, assign an auto generated id and then continue processing the packet as it originally contained a non zero byte id.

On the other hand, the Client may allow to connect with no credentials in which case it can send a zero bytes client id to the Broker or assign an auto generated id before sending the packet.
If the client connects as anonymous, it must set the "clean session" field to true.

This PR contains changes for both Server and Client.

- Server: allows to receive zero bytes client id and assign an auto generated id at the time of formatting the packet to then continue processing it as usual
- Client: allows to connect without credentials, in which case it will enforce to receive the "clean session" field in true and will auto generate a client id to the send it as usual.

We are auto generating the anonymous client id in the Client side instead of sendind a zero byte id to the Broker becase the spec allows it and it's also more consistent to handle client sessions in both client and server with the same id.
The support in the Server to receive zero bytes has been added to follow the spec and also if by any chance other MQTT client than this sends a CONNECT packet with zero bytes client id.

More information about zero bytes client ids: http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718031