### PR TITLE
Propagate the `Retain` flag to the `MqttApplicationMessage`

### DIFF
--- a/src/Client/MqttApplicationMessage.cs
+++ b/src/Client/MqttApplicationMessage.cs
@@ -21,15 +21,37 @@
             Payload = payload;
 		}
 
-        /// <summary>
-        /// Topic associated with the message
-        /// Any subscriber of this topic should receive the corresponding messages
-        /// </summary>
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MqttApplicationMessage" /> class,
+		/// specifying the topic and payload of the message
+		/// </summary>
+		/// <param name="topic">
+		/// Topic associated with the message
+		/// Any subscriber of this topic should receive the corresponding messages
+		/// </param>
+		/// <param name="payload">Content of the message, as a byte array</param>
+		/// <param name="retain">Indicates if this message was published with the retain flag</param>
+		public MqttApplicationMessage(string topic, byte[] payload, bool retain)
+		{
+			Topic = topic;
+			Payload = payload;
+			Retain = retain;
+		}
+
+		/// <summary>
+		/// Topic associated with the message
+		/// Any subscriber of this topic should receive the corresponding messages
+		/// </summary>
 		public string Topic { get; }
 
         /// <summary>
         /// Content of the message, as a byte array
         /// </summary>
 		public byte[] Payload { get; }
+
+		/// <summary>
+		/// Indicates if this message was published with the retain flag
+		/// </summary>
+		public bool Retain { get; }
 	}
 }

--- a/src/Client/Sdk/MqttClientImpl.cs
+++ b/src/Client/Sdk/MqttClientImpl.cs
@@ -411,7 +411,7 @@ namespace System.Net.Mqtt.Sdk
 				.Subscribe (packet => {
 					if (packet.Type == MqttPacketType.Publish) {
 						var publish = packet as Publish;
-						var message = new MqttApplicationMessage (publish.Topic, publish.Payload);
+						var message = new MqttApplicationMessage (publish.Topic, publish.Payload, publish.Retain);
 
 						receiver.OnNext (message);
 						tracer.Info (Properties.Resources.Client_NewApplicationMessageReceived, Id, publish.Topic);

--- a/src/Server/Sdk/Flows/ServerPublishReceiverFlow.cs
+++ b/src/Server/Sdk/Flows/ServerPublishReceiverFlow.cs
@@ -97,7 +97,7 @@ namespace System.Net.Mqtt.Sdk.Flows
 			if (!subscriptions.Any ()) {
 				tracer.Verbose (Server.Properties.Resources.ServerPublishReceiverFlow_TopicNotSubscribed, publish.Topic, clientId);
 
-				undeliveredMessagesListener.OnNext (new MqttUndeliveredMessage { SenderId = clientId, Message = new MqttApplicationMessage (publish.Topic, publish.Payload) });
+				undeliveredMessagesListener.OnNext (new MqttUndeliveredMessage { SenderId = clientId, Message = new MqttApplicationMessage (publish.Topic, publish.Payload, publish.Retain) });
 			} else {
 				foreach (var subscription in subscriptions) {
 					await DispatchAsync (publish, subscription, isWill)


### PR DESCRIPTION
In some cases, it's useful to know if the message received was published with the "Retain" flag or not (for instance, if so, we are able to cache the value locally)