### PR TITLE
 Fixed MessageStream potential hang in MQTT Client

### DIFF
--- a/src/Client/IMqttClient.cs
+++ b/src/Client/IMqttClient.cs
@@ -7,26 +7,26 @@ namespace System.Net.Mqtt
 	/// </summary>
 	public interface IMqttClient : IDisposable
 	{
-        /// <summary>
-        /// Event raised when the Client gets disconnected.
-        /// The Client disconnection could be caused by a protocol disconnect, 
-        /// an error or a remote disconnection produced by the Server.
-        /// See <see cref="MqttEndpointDisconnected"/> for more details on the disconnection information
-        /// </summary>
+		/// <summary>
+		/// Event raised when the Client gets disconnected.
+		/// The Client disconnection could be caused by a protocol disconnect, 
+		/// an error or a remote disconnection produced by the Server.
+		/// See <see cref="MqttEndpointDisconnected"/> for more details on the disconnection information
+		/// </summary>
 		event EventHandler<MqttEndpointDisconnected> Disconnected;
 
-        /// <summary>
-        /// Id of the connected Client.
-        /// This Id correspond to the <see cref="MqttClientCredentials.ClientId"/> parameter passed to 
-        /// <see cref="ConnectAsync (MqttClientCredentials, MqttLastWill, bool)"/> method
-        /// </summary>
+		/// <summary>
+		/// Id of the connected Client.
+		/// This Id correspond to the <see cref="MqttClientCredentials.ClientId"/> parameter passed to 
+		/// <see cref="ConnectAsync (MqttClientCredentials, MqttLastWill, bool)"/> method
+		/// </summary>
 		string Id { get; }
 
-        /// <summary>
-        /// Indicates if the Client is connected by protocol.
-        /// This means that a CONNECT packet has been sent, 
-        /// by calling <see cref="ConnectAsync (MqttClientCredentials, MqttLastWill, bool)"/> method
-        /// </summary>
+		/// <summary>
+		/// Indicates if the Client is connected by protocol.
+		/// This means that a CONNECT packet has been sent, 
+		/// by calling <see cref="ConnectAsync (MqttClientCredentials, MqttLastWill, bool)"/> method
+		/// </summary>
 		bool IsConnected { get; }
 
 		/// <summary>
@@ -67,7 +67,7 @@ namespace System.Net.Mqtt
 		/// See <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html#_Toc442180841">MQTT Connect</a>
 		/// for more details about the protocol connection
 		/// </remarks>
-		Task<SessionState> ConnectAsync (MqttClientCredentials credentials, MqttLastWill will = null, bool cleanSession = false);
+		Task<SessionState> ConnectAsync(MqttClientCredentials credentials, MqttLastWill will = null, bool cleanSession = false);
 
 		/// <summary>
 		/// Represents the protocol connection, which consists of sending a CONNECT packet
@@ -88,7 +88,7 @@ namespace System.Net.Mqtt
 		/// See <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html#_Toc442180841">MQTT Connect</a>
 		/// for more details about the protocol connection
 		/// </remarks>
-		Task<SessionState> ConnectAsync (MqttLastWill will = null);
+		Task<SessionState> ConnectAsync(MqttLastWill will = null);
 
 		/// <summary>
 		/// Represents the protocol subscription, which consists of sending a SUBSCRIBE packet
@@ -108,55 +108,55 @@ namespace System.Net.Mqtt
 		/// See <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html#_Toc442180876">MQTT Subscribe</a>
 		/// for more details about the protocol subscription
 		/// </remarks>
-		Task SubscribeAsync (string topicFilter, MqttQualityOfService qos);
+		Task SubscribeAsync(string topicFilter, MqttQualityOfService qos);
 
-        /// <summary>
-        /// Represents the protocol publish, which consists of sending a PUBLISH packet
-        /// and awaiting the corresponding ACK packet, if applies, based on the QoS defined
-        /// </summary>
-        /// <param name="message">
-        /// The application message to publish to the Server.
-        /// See <see cref="MqttApplicationMessage" /> for more details about the application messages
-        /// </param>
-        /// <param name="qos">
-        /// The Quality Of Service (QoS) associated to the application message, which determines 
-        /// the sequence of acknowledgements that Client and Server should send each other to consider the message as delivered
-        /// See <see cref="MqttQualityOfService" /> for more details about the QoS values
-        /// </param>
-        /// <param name="retain">
-        /// Indicates if the application message should be retained by the Server for future subscribers.
-        /// Only the last message of each topic is retained
-        /// </param>
-        /// <remarks>
-        /// See <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html#_Toc442180850">MQTT Publish</a>
-        /// for more details about the protocol publish
-        /// </remarks>
-        Task PublishAsync (MqttApplicationMessage message, MqttQualityOfService qos, bool retain = false);
+		/// <summary>
+		/// Represents the protocol publish, which consists of sending a PUBLISH packet
+		/// and awaiting the corresponding ACK packet, if applies, based on the QoS defined
+		/// </summary>
+		/// <param name="message">
+		/// The application message to publish to the Server.
+		/// See <see cref="MqttApplicationMessage" /> for more details about the application messages
+		/// </param>
+		/// <param name="qos">
+		/// The Quality Of Service (QoS) associated to the application message, which determines 
+		/// the sequence of acknowledgements that Client and Server should send each other to consider the message as delivered
+		/// See <see cref="MqttQualityOfService" /> for more details about the QoS values
+		/// </param>
+		/// <param name="retain">
+		/// Indicates if the application message should be retained by the Server for future subscribers.
+		/// Only the last message of each topic is retained
+		/// </param>
+		/// <remarks>
+		/// See <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html#_Toc442180850">MQTT Publish</a>
+		/// for more details about the protocol publish
+		/// </remarks>
+		Task PublishAsync(MqttApplicationMessage message, MqttQualityOfService qos, bool retain = false);
 
-        /// <summary>
-        /// Represents the protocol unsubscription, which consists of sending an UNSUBSCRIBE packet
-        /// and awaiting the corresponding UNSUBACK packet from the Server
-        /// </summary>
-        /// <param name="topics">
-        /// The list of topics to unsubscribe from
-        /// Once the unsubscription completes, no more application messages for those topics will arrive to <see cref="MessageStream"/> 
-        /// </param>
-        /// <exception cref="MqttClientException">MqttClientException</exception>
-        /// <remarks>
-        /// See <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html#_Toc442180885">MQTT Unsubscribe</a>
-        /// for more details about the protocol unsubscription
-        /// </remarks>
-		Task UnsubscribeAsync (params string[] topics);
+		/// <summary>
+		/// Represents the protocol unsubscription, which consists of sending an UNSUBSCRIBE packet
+		/// and awaiting the corresponding UNSUBACK packet from the Server
+		/// </summary>
+		/// <param name="topics">
+		/// The list of topics to unsubscribe from
+		/// Once the unsubscription completes, no more application messages for those topics will arrive to <see cref="MessageStream"/> 
+		/// </param>
+		/// <exception cref="MqttClientException">MqttClientException</exception>
+		/// <remarks>
+		/// See <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html#_Toc442180885">MQTT Unsubscribe</a>
+		/// for more details about the protocol unsubscription
+		/// </remarks>
+		Task UnsubscribeAsync(params string[] topics);
 
-        /// <summary>
-        /// Represents the protocol disconnection, which consists of sending a DISCONNECT packet to the Server
-        /// No acknowledgement is sent by the Server on the disconnection
-        /// Once the client is successfully disconnected, the <see cref="Disconnected"/> event will be fired 
-        /// </summary>
-        /// <remarks>
-        /// See <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html#_Toc442180903">MQTT Disconnect</a>
-        /// for more details about the protocol disconnection
-        /// </remarks>
-		Task DisconnectAsync ();
+		/// <summary>
+		/// Represents the protocol disconnection, which consists of sending a DISCONNECT packet to the Server
+		/// No acknowledgement is sent by the Server on the disconnection
+		/// Once the client is successfully disconnected, the <see cref="Disconnected"/> event will be fired 
+		/// </summary>
+		/// <remarks>
+		/// See <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html#_Toc442180903">MQTT Disconnect</a>
+		/// for more details about the protocol disconnection
+		/// </remarks>
+		Task DisconnectAsync();
 	}
 }

--- a/src/Client/IMqttClient.cs
+++ b/src/Client/IMqttClient.cs
@@ -29,12 +29,17 @@ namespace System.Net.Mqtt
         /// </summary>
 		bool IsConnected { get; }
 
-        /// <summary>
-        /// Represents the incoming application messages received from the Server
-        /// These messages correspond to the topics subscribed,
-        /// by calling <see cref="SubscribeAsync(string, MqttQualityOfService)"/> method 
-        /// See <see cref="MqttApplicationMessage"/> for more details about the application messages
-        /// </summary>
+		/// <summary>
+		/// Represents the incoming application messages received from the Server
+		/// These messages correspond to the topics subscribed,
+		/// by calling <see cref="SubscribeAsync(string, MqttQualityOfService)"/> method 
+		/// See <see cref="MqttApplicationMessage"/> for more details about the application messages
+		/// </summary>
+		/// <remarks>
+		/// The stream lifecycle ends when the client is disconnected, either by a protocol disconnect, 
+		/// an error or a remote disconnection produced by the Server.
+		/// The stream subscritpions should be created again if the client is intended to be re-connected
+		/// </remarks>
 		IObservable<MqttApplicationMessage> MessageStream { get; }
 
 		/// <summary>

--- a/src/IntegrationTests/ConnectionSpec.cs
+++ b/src/IntegrationTests/ConnectionSpec.cs
@@ -502,6 +502,25 @@ namespace IntegrationTests
 			client3.Dispose();
 		}
 
+		[Fact]
+		public async Task when_client_disconnects_then_message_stream_completes()
+		{
+			var streamCompletedSignal = new ManualResetEventSlim(initialState: false);
+			var client = await GetClientAsync();
+
+			await client.ConnectAsync(new MqttClientCredentials(GetClientId()));
+
+			client.MessageStream.Subscribe(_ => { }, onCompleted: () => streamCompletedSignal.Set());
+
+			await client.DisconnectAsync();
+
+			var streamCompleted = streamCompletedSignal.Wait(2000);
+
+			Assert.True(streamCompleted);
+
+			client.Dispose();
+		}
+
 		public void Dispose() => server?.Dispose();
 	}
 }


### PR DESCRIPTION
Previous to this change, the IMqttClient.MessageStream property life cycle was defined from the instance creation to the instance disposal. This means that the IObservable would never be completed even if the client is disconnected.

So, if any consumer was awaiting an Rx expression over the IObservable and the client is disconnected before the expression condition is met, then that await would never complete because the sequence will still be active no matter if the client is still connected or not.

This bug forced an analysis about whether this life cycle was correct or not. We determined that given that the messages only makes sense from the client connection to the client disconnection; then we should be resetting the MessageStream once the client is disconnected. Resetting the MessageStream means completing it (because the current client cycle finished) and then re-create it to allow it to be consumed if the client is meant to be re-used or re-connected.

Doing this, the stream will complete immediately after the disconnection takes place, releasing any existing MessageStream consumer that is blocked awaiting for a condition that will never be met.

The only side effect of this, but is part of the design and perfectly logic, is that if the client is re-used then the Rx subscriptions over the MessageStream will need to be created again because the MessageStream is reset together with the existing Rx subscriptions.