### PR TITLE
Added concurrency control to IMqttChannel implementations

### DIFF
--- a/src/Client/Sdk/AsyncLock.cs
+++ b/src/Client/Sdk/AsyncLock.cs
@@ -1,0 +1,42 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Mqtt.Sdk
+{
+	internal class AsyncLock
+	{
+		readonly SemaphoreSlim semaphore;
+		readonly Releaser releaser;
+
+		public AsyncLock()
+		{
+			semaphore = new SemaphoreSlim(1, 1);
+			releaser = new Releaser(this);
+		}
+
+		public async Task<IDisposable> LockAsync()
+		{
+			await semaphore.WaitAsync();
+
+			return releaser;
+		}
+
+		private class Releaser : IDisposable
+		{
+			readonly AsyncLock lockObject;
+
+			internal Releaser(AsyncLock lockObject)
+			{
+				this.lockObject = lockObject;
+			}
+
+			public void Dispose()
+			{
+				if (lockObject != null)
+				{
+					lockObject.semaphore.Release();
+				}
+			}
+		}
+	}
+}

--- a/src/Client/Sdk/IMqttChannel.cs
+++ b/src/Client/Sdk/IMqttChannel.cs
@@ -6,30 +6,36 @@ namespace System.Net.Mqtt.Sdk
 	/// Represents a mechanism to send and receive information between two endpoints
 	/// </summary>
 	/// <typeparam name="T">The type of information that will go through the channel</typeparam>
-	public interface IMqttChannel<T> : IDisposable
+	public interface IMqttChannel<T>
 	{
-        /// <summary>
-        /// Indicates if the channel is connected to the underlying stream or not
-        /// </summary>
+		/// <summary>
+		/// Indicates if the channel is connected to the underlying stream or not
+		/// </summary>
 		bool IsConnected { get; }
 
-        /// <summary>
-        /// Represents the stream of incoming information received by the channel
-        /// </summary>
+		/// <summary>
+		/// Represents the stream of incoming information received by the channel
+		/// </summary>
 		IObservable<T> ReceiverStream { get; }
 
-        /// <summary>
-        /// Represents the stream of outgoing information sent by the channel
-        /// </summary>
+		/// <summary>
+		/// Represents the stream of outgoing information sent by the channel
+		/// </summary>
 		IObservable<T> SenderStream { get; }
 
-        /// <summary>
-        /// Sends information to the other end, through the underlying stream
-        /// </summary>
-        /// <param name="message">
-        /// Message to send to the other end of the channel
-        /// </param>
+		/// <summary>
+		/// Sends information to the other end, through the underlying stream
+		/// </summary>
+		/// <param name="message">
+		/// Message to send to the other end of the channel
+		/// </param>
 		/// <exception cref="MqttException">MqttException</exception>
-		Task SendAsync (T message);
+		Task SendAsync(T message);
+
+		/// <summary>
+		/// Closes the channel for communication and completes all the associated streams
+		/// </summary>
+		/// <returns></returns>
+		Task CloseAsync();
 	}
 }

--- a/src/Client/Sdk/ThreadingExtensions.cs
+++ b/src/Client/Sdk/ThreadingExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace System.Net.Mqtt.Sdk
+{
+	internal static class ThreadingExtensions
+	{
+		static readonly ITracer tracer = Tracer.Get(typeof(ThreadingExtensions));
+
+		internal static async void FireAndForget(this Task task)
+		{
+			try
+			{
+				await task.ConfigureAwait(continueOnCapturedContext: false);
+			}
+			catch (Exception ex)
+			{
+				tracer.Error(ex);
+			}
+		}
+	}
+}

--- a/src/IntegrationTests/ConnectionSpec.cs
+++ b/src/IntegrationTests/ConnectionSpec.cs
@@ -492,7 +492,7 @@ namespace IntegrationTests
 			}));
 
 			//Forces socket disconnection without using protocol Disconnect (Disconnect or Dispose Client method)
-			(client1 as MqttClientImpl).Channel.Dispose();
+			await (client1 as MqttClientImpl).Channel.CloseAsync();
 
 			var willReceived = willReceivedSignal.Wait(2000);
 

--- a/src/Server/Sdk/Bindings/PrivateChannel.cs
+++ b/src/Server/Sdk/Bindings/PrivateChannel.cs
@@ -8,99 +8,114 @@ using ClientProperties = System.Net.Mqtt.Properties;
 namespace System.Net.Mqtt.Sdk.Bindings
 {
 	internal class PrivateChannel : IMqttChannel<byte[]>
-    {
-        static readonly ITracer tracer = Tracer.Get<PrivateChannel>();
+	{
+		static readonly ITracer tracer = Tracer.Get<PrivateChannel>();
 
-        bool disposed;
+		volatile bool closed;
 
-        readonly PrivateStream stream;
-        readonly EndpointIdentifier identifier;
-        readonly ReplaySubject<byte[]> receiver;
-        readonly ReplaySubject<byte[]> sender;
-        readonly IDisposable streamSubscription;
+		readonly PrivateStream stream;
+		readonly EndpointIdentifier identifier;
+		readonly ReplaySubject<byte[]> receiver;
+		readonly ReplaySubject<byte[]> sender;
+		readonly IDisposable streamSubscription;
+		readonly AsyncLock asyncLockObject;
 
-        public PrivateChannel (PrivateStream stream, EndpointIdentifier identifier, MqttConfiguration configuration)
-        {
-            this.stream = stream;
-            this.identifier = identifier;
-            receiver = new ReplaySubject<byte[]> (window: TimeSpan.FromSeconds(configuration.WaitTimeoutSecs));
-            sender = new ReplaySubject<byte[]> (window: TimeSpan.FromSeconds(configuration.WaitTimeoutSecs));
-            streamSubscription = SubscribeStream ();
-        }
+		public PrivateChannel(PrivateStream stream, EndpointIdentifier identifier, MqttConfiguration configuration)
+		{
+			this.stream = stream;
+			this.identifier = identifier;
+			receiver = new ReplaySubject<byte[]>(window: TimeSpan.FromSeconds(configuration.WaitTimeoutSecs));
+			sender = new ReplaySubject<byte[]>(window: TimeSpan.FromSeconds(configuration.WaitTimeoutSecs));
+			streamSubscription = SubscribeStream();
+			asyncLockObject = new AsyncLock();
+		}
 
-        public bool IsConnected => !stream.IsDisposed;
+		public bool IsConnected => !stream.IsDisposed;
 
-        public IObservable<byte[]> ReceiverStream => receiver;
+		public IObservable<byte[]> ReceiverStream => receiver;
 
-        public IObservable<byte[]> SenderStream => sender;
+		public IObservable<byte[]> SenderStream => sender;
 
-        public Task SendAsync (byte[] message)
-        {
-            if (disposed) {
-                throw new ObjectDisposedException (nameof (PrivateChannel));
-            }
+		public async Task SendAsync(byte[] message)
+		{
+			if (!closed)
+			{
+				using (await asyncLockObject.LockAsync().ConfigureAwait(continueOnCapturedContext: false))
+				{
+					if (!closed)
+					{
+						if (!IsConnected)
+						{
+							throw new MqttException(ClientProperties.Resources.MqttChannel_ClientNotConnected);
+						}
 
-            if (!IsConnected) {
-                throw new MqttException (ClientProperties.Resources.MqttChannel_ClientNotConnected);
-            }
+						sender.OnNext(message);
 
-            sender.OnNext (message);
+						try
+						{
+							tracer.Verbose(ClientProperties.Resources.MqttChannel_SendingPacket, message.Length);
 
-            try {
-                tracer.Verbose (ClientProperties.Resources.MqttChannel_SendingPacket, message.Length);
+							stream.Send(message, identifier);
+						}
+						catch (ObjectDisposedException disposedEx)
+						{
+							throw new MqttException(ClientProperties.Resources.MqttChannel_StreamDisconnected, disposedEx);
+						}
+					}
+				}
+			}
+		}
 
-                stream.Send (message, identifier);
+		public async Task CloseAsync()
+		{
+			if (!closed)
+			{
+				using (await asyncLockObject.LockAsync().ConfigureAwait(continueOnCapturedContext: false))
+				{
+					if (!closed)
+					{
+						tracer.Info(Properties.Resources.Mqtt_Disposing, nameof(PrivateChannel));
 
-                return Task.FromResult (true);
-            } catch (ObjectDisposedException disposedEx) {
-                throw new MqttException (ClientProperties.Resources.MqttChannel_StreamDisconnected, disposedEx);
-            }
-        }
+						streamSubscription.Dispose();
+						receiver.OnCompleted();
+						sender.OnCompleted();
+						stream.Dispose();
 
-        public void Dispose ()
-        {
-            Dispose (disposing: true);
-            GC.SuppressFinalize (this);
-        }
+						closed = true;
+					}
+				}
+			}
+		}
 
-        protected virtual void Dispose (bool disposing)
-        {
-            if (disposed) return;
+		IDisposable SubscribeStream()
+		{
+			var senderIdentifier = identifier == EndpointIdentifier.Client ?
+				EndpointIdentifier.Server :
+				EndpointIdentifier.Client;
 
-            if (disposing) {
-                tracer.Info (Properties.Resources.Mqtt_Disposing, nameof (PrivateChannel));
+			return stream
+				.Receive(senderIdentifier)
+				.ObserveOn(NewThreadScheduler.Default)
+				.Subscribe(packet =>
+				{
+					tracer.Verbose(ClientProperties.Resources.MqttChannel_ReceivedPacket, packet.Length);
 
-                streamSubscription.Dispose ();
-                receiver.OnCompleted ();
-                stream.Dispose ();
-
-                disposed = true;
-            }
-        }
-
-        IDisposable SubscribeStream ()
-        {
-            var senderIdentifier = identifier == EndpointIdentifier.Client ?
-                EndpointIdentifier.Server :
-                EndpointIdentifier.Client;
-
-            return stream
-                .Receive (senderIdentifier)
-                .ObserveOn (NewThreadScheduler.Default)
-                .Subscribe (packet => {
-                    tracer.Verbose(ClientProperties.Resources.MqttChannel_ReceivedPacket, packet.Length);
-
-                    receiver.OnNext (packet);
-                }, ex => {
-                    if (ex is ObjectDisposedException) {
-                        receiver.OnError (new MqttException (ClientProperties.Resources.MqttChannel_StreamDisconnected, ex));
-                    } else {
-                        receiver.OnError (ex);
-                    }
-                }, () => {
-                    tracer.Warn (ClientProperties.Resources.MqttChannel_NetworkStreamCompleted);
-                    receiver.OnCompleted ();
-                });
-        }
-    }
+					receiver.OnNext(packet);
+				}, ex =>
+				{
+					if (ex is ObjectDisposedException)
+					{
+						receiver.OnError(new MqttException(ClientProperties.Resources.MqttChannel_StreamDisconnected, ex));
+					}
+					else
+					{
+						receiver.OnError(ex);
+					}
+				}, () =>
+				{
+					tracer.Warn(ClientProperties.Resources.MqttChannel_NetworkStreamCompleted);
+					receiver.OnCompleted();
+				});
+		}
+	}
 }

--- a/src/Server/Sdk/Flows/DisconnectFlow.cs
+++ b/src/Server/Sdk/Flows/DisconnectFlow.cs
@@ -28,7 +28,7 @@ namespace System.Net.Mqtt.Sdk.Flows
 				return;
 			}
 
-			await Task.Run (() => {
+			await Task.Run (async () => {
 				var disconnect = input as Disconnect;
 
 				tracer.Info (Server.Properties.Resources.DisconnectFlow_Disconnecting, clientId);
@@ -47,7 +47,9 @@ namespace System.Net.Mqtt.Sdk.Flows
 					tracer.Info (Server.Properties.Resources.Server_DeletedSessionOnDisconnect, clientId);
 				}
 
-				connectionProvider.RemoveConnection (clientId);
+				await connectionProvider
+					.RemoveConnectionAsync (clientId)
+					.ConfigureAwait(continueOnCapturedContext: false);
 			});
 		}
 	}

--- a/src/Server/Sdk/Flows/ServerPublishReceiverFlow.cs
+++ b/src/Server/Sdk/Flows/ServerPublishReceiverFlow.cs
@@ -115,7 +115,9 @@ namespace System.Net.Mqtt.Sdk.Flows
 			var subscriptionPublish = new Publish (publish.Topic, supportedQos, retain, duplicated: false, packetId: packetId) {
 				Payload = publish.Payload
 			};
-			var clientChannel = connectionProvider.GetConnection (subscription.ClientId);
+			var clientChannel = await connectionProvider
+				.GetConnectionAsync (subscription.ClientId)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			await senderFlow.SendPublishAsync (subscription.ClientId, subscriptionPublish, clientChannel)
 				.ConfigureAwait (continueOnCapturedContext: false);

--- a/src/Server/Sdk/IConnectionProvider.cs
+++ b/src/Server/Sdk/IConnectionProvider.cs
@@ -1,22 +1,23 @@
 ﻿using System.Collections.Generic;
 using System.Net.Mqtt.Sdk.Packets;
+using System.Threading.Tasks;
 
 namespace System.Net.Mqtt.Sdk
 {
-    internal interface IConnectionProvider
+	internal interface IConnectionProvider
 	{
 		int Connections { get; }
 
 		IEnumerable<string> ActiveClients { get; }
 
-        IEnumerable<string> PrivateClients { get; }
+		IEnumerable<string> PrivateClients { get; }
 
-        void RegisterPrivateClient (string clientId);
+		void RegisterPrivateClient(string clientId);
 
-		void AddConnection (string clientId, IMqttChannel<IPacket> connection);
+		Task AddConnectionAsync(string clientId, IMqttChannel<IPacket> connection);
 
-		IMqttChannel<IPacket> GetConnection (string clientId);
+		Task<IMqttChannel<IPacket>> GetConnectionAsync(string clientId);
 
-		void RemoveConnection (string clientId);
+		Task RemoveConnectionAsync(string clientId);
 	}
 }

--- a/src/Server/Sdk/MqttServerImpl.cs
+++ b/src/Server/Sdk/MqttServerImpl.cs
@@ -159,13 +159,13 @@ namespace System.Net.Mqtt.Sdk
 			packetListener.Listen ();
 			packetListener
                 .PacketStream
-                .Subscribe (_ => { }, async ex => {
+                .Subscribe (_ => { }, ex => {
 				        tracer.Error (ex, ServerProperties.Resources.Server_PacketsObservableError);
-				        await packetChannel.CloseAsync ().ConfigureAwait(continueOnCapturedContext: false);
+						packetChannel.CloseAsync ().FireAndForget ();
 				        packetListener.Dispose ();
-			        }, async () => {
+			        }, () => {
 				        tracer.Warn (ServerProperties.Resources.Server_PacketsObservableCompleted);
-				        await packetChannel.CloseAsync ().ConfigureAwait(continueOnCapturedContext: false);
+						packetChannel.CloseAsync ().FireAndForget ();
 				        packetListener.Dispose ();
 			        }
                 );

--- a/src/Tests/ConnectionProviderSpec.cs
+++ b/src/Tests/ConnectionProviderSpec.cs
@@ -2,10 +2,11 @@
 using System;
 using System.Linq;
 using System.Net.Mqtt;
+using System.Net.Mqtt.Sdk;
 using System.Net.Mqtt.Sdk.Packets;
 using System.Reactive.Subjects;
+using System.Threading.Tasks;
 using Xunit;
-using System.Net.Mqtt.Sdk;
 
 namespace Tests
 {
@@ -39,18 +40,18 @@ namespace Tests
         }
 
         [Fact]
-        public void when_removing_private_connection_then_private_client_list_decreases()
+        public async Task when_removing_private_connection_then_private_client_list_decreases()
         {
             var provider = new ConnectionProvider ();
 
             var clientId = Guid.NewGuid ().ToString ();
 
-            provider.AddConnection (clientId, Mock.Of<IMqttChannel<IPacket>> (c => c.IsConnected == true));
+            await provider.AddConnectionAsync (clientId, Mock.Of<IMqttChannel<IPacket>> (c => c.IsConnected == true));
             provider.RegisterPrivateClient (clientId);
 
             var previousPrivateClients = provider.PrivateClients.Count ();
 
-            provider.RemoveConnection (clientId);
+            await provider.RemoveConnectionAsync (clientId);
 
             var currentPrivateClients = provider.PrivateClients.Count ();
 
@@ -58,33 +59,33 @@ namespace Tests
         }
 
         [Fact]
-		public void when_adding_new_client_then_connection_list_increases()
+		public async Task when_adding_new_client_then_connection_list_increases()
 		{
 			var provider = new ConnectionProvider ();
 
 			var existingClients = provider.Connections;
 			var clientId = Guid.NewGuid ().ToString ();
 
-			provider.AddConnection (clientId, Mock.Of<IMqttChannel<IPacket>> (c => c.IsConnected == true));
+			await provider.AddConnectionAsync (clientId, Mock.Of<IMqttChannel<IPacket>>(c => c.IsConnected == true)); 
 
 			Assert.Equal (existingClients + 1, provider.Connections);
 		}
 
 		[Fact]
-		public void when_adding_disconnected_client_then_active_clients_list_does_not_increases()
+		public async Task when_adding_disconnected_client_then_active_clients_list_does_not_increases()
 		{
 			var provider = new ConnectionProvider ();
 
 			var existingClients = provider.ActiveClients.Count();
 			var clientId = Guid.NewGuid ().ToString ();
 
-			provider.AddConnection (clientId, Mock.Of<IMqttChannel<IPacket>> (c => c.IsConnected == false));
+			await provider.AddConnectionAsync (clientId, Mock.Of<IMqttChannel<IPacket>>(c => c.IsConnected == false)); 
 
 			Assert.Equal (existingClients, provider.ActiveClients.Count());
 		}
 
 		[Fact]
-		public void when_adding_new_client_and_disconnect_it_then_active_clients_list_decreases()
+		public async Task when_adding_new_client_and_disconnect_it_then_active_clients_list_decreases()
 		{
 			var provider = new ConnectionProvider ();
 
@@ -95,7 +96,7 @@ namespace Tests
 
 			connection.Setup(c => c.IsConnected).Returns(true);
 
-			provider.AddConnection (clientId, connection.Object);
+			await provider.AddConnectionAsync (clientId, connection.Object);
 
 			var currentClients = provider.ActiveClients.Count();
 
@@ -108,7 +109,7 @@ namespace Tests
 		}
 
 		[Fact]
-		public void when_removing_clients_then_connection_list_decreases()
+		public async Task when_removing_clients_then_connection_list_decreases()
 		{
 			var provider = new ConnectionProvider ();
 
@@ -116,11 +117,11 @@ namespace Tests
 
 			var clientId = Guid.NewGuid ().ToString ();
 
-			provider.AddConnection (clientId, Mock.Of<IMqttChannel<IPacket>> (c => c.IsConnected == true));
+			await provider.AddConnectionAsync (clientId, Mock.Of<IMqttChannel<IPacket>> (c => c.IsConnected == true));
 
 			var newClients = provider.Connections;
 
-			provider.RemoveConnection (clientId);
+			await provider.RemoveConnectionAsync(clientId); 
 
 			var finalClients = provider.Connections;
 
@@ -129,7 +130,7 @@ namespace Tests
 		}
 
 		[Fact]
-		public void when_adding_existing_client_id_then_existing_client_is_disconnected()
+		public async Task when_adding_existing_client_id_then_existing_client_is_disconnected()
 		{
 			var provider = new ConnectionProvider ();
 
@@ -147,35 +148,35 @@ namespace Tests
 
 			var clientId = Guid.NewGuid().ToString();
 
-			provider.AddConnection (clientId, channel1.Object);
-			provider.AddConnection (clientId, channel2.Object);
+			await provider.AddConnectionAsync (clientId, channel1.Object);
+			await provider.AddConnectionAsync (clientId, channel2.Object);
 
-			channel1.Verify (c => c.Dispose ());
-			channel2.Verify(c => c.Dispose(), Times.Never);
+			channel1.Verify (c => c.CloseAsync ());
+			channel2.Verify(c => c.CloseAsync (), Times.Never);
 		}
 
 		[Fact]
-		public void when_getting_connection_from_client_then_succeeds()
+		public async Task when_getting_connection_from_client_then_succeeds()
 		{
 			var provider = new ConnectionProvider ();
 			var clientId = Guid.NewGuid ().ToString ();
 
-			provider.AddConnection (clientId, Mock.Of<IMqttChannel<IPacket>> (c => c.IsConnected == true));
+			await provider.AddConnectionAsync (clientId, Mock.Of<IMqttChannel<IPacket>> (c => c.IsConnected == true));
 
-			var connection = provider.GetConnection (clientId);
+			var connection = await provider.GetConnectionAsync (clientId);
 
 			Assert.NotNull (connection);
 		}
 
 		[Fact]
-		public void when_getting_connection_from_disconnected_client_then_no_connection_is_returned()
+		public async Task when_getting_connection_from_disconnected_client_then_no_connection_is_returned()
 		{
 			var provider = new ConnectionProvider ();
 			var clientId = Guid.NewGuid ().ToString ();
 
-			provider.AddConnection (clientId, Mock.Of<IMqttChannel<IPacket>> (c => c.IsConnected == false));
+			await provider.AddConnectionAsync (clientId, Mock.Of<IMqttChannel<IPacket>> (c => c.IsConnected == false));
 
-			var connection = provider.GetConnection (clientId);
+			var connection = await provider.GetConnectionAsync (clientId);
 
 			Assert.Null (connection);
 		}

--- a/src/Tests/Flows/ConnectFlowSpec.cs
+++ b/src/Tests/Flows/ConnectFlowSpec.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Mqtt;
 using System.Net.Mqtt.Sdk;
 using System.Net.Mqtt.Sdk.Flows;
@@ -34,8 +33,8 @@ namespace Tests.Flows
 			var connectionProvider = new Mock<IConnectionProvider> ();
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (c => c == clientId)))
-				.Returns (channel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (c => c == clientId)))
+				.Returns (Task.FromResult(channel.Object));
 
 			var flow = new ServerConnectFlow (authenticationProvider, sessionRepository.Object, willRepository.Object, senderFlow.Object);
 
@@ -83,8 +82,8 @@ namespace Tests.Flows
 			var connectionProvider = new Mock<IConnectionProvider> ();
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (c => c == clientId)))
-				.Returns (channel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (c => c == clientId)))
+				.Returns (Task.FromResult(channel.Object));
 
 			var flow = new ServerConnectFlow (authenticationProvider, sessionRepository.Object, willRepository.Object, senderFlow.Object);
 
@@ -130,8 +129,8 @@ namespace Tests.Flows
 			var connectionProvider = new Mock<IConnectionProvider> ();
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (c => c == clientId)))
-				.Returns (channel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (c => c == clientId)))
+				.Returns (Task.FromResult(channel.Object));
 
 			var flow = new ServerConnectFlow (authenticationProvider, sessionRepository.Object, willRepository.Object, senderFlow.Object);
 
@@ -176,8 +175,8 @@ namespace Tests.Flows
 			var connectionProvider = new Mock<IConnectionProvider> ();
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (c => c == clientId)))
-				.Returns (channel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (c => c == clientId)))
+				.Returns (Task.FromResult(channel.Object));
 
 			var flow = new ServerConnectFlow (authenticationProvider, sessionRepository.Object, willRepository.Object, senderFlow.Object);
 
@@ -216,8 +215,8 @@ namespace Tests.Flows
 			var connectionProvider = new Mock<IConnectionProvider> ();
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (c => c == clientId)))
-				.Returns (channel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (c => c == clientId)))
+				.Returns (Task.FromResult(channel.Object));
 
 			var flow = new ServerConnectFlow (authenticationProvider, sessionRepository.Object, willRepository.Object, senderFlow.Object);
 
@@ -256,8 +255,8 @@ namespace Tests.Flows
 			var connectionProvider = new Mock<IConnectionProvider> ();
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (c => c == clientId)))
-				.Returns (channel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (c => c == clientId)))
+				.Returns (Task.FromResult(channel.Object));
 
 			var flow = new ServerConnectFlow (authenticationProvider, sessionRepository.Object, willRepository.Object, senderFlow.Object);
 
@@ -355,8 +354,8 @@ namespace Tests.Flows
 			var connectionProvider = new Mock<IConnectionProvider>();
 
 			connectionProvider
-				.Setup(p => p.GetConnection(It.Is<string>(c => c == clientId)))
-				.Returns(channel.Object);
+				.Setup(p => p.GetConnectionAsync (It.Is<string>(c => c == clientId)))
+				.Returns(Task.FromResult(channel.Object));
 
 			var flow = new ServerConnectFlow(authenticationProvider, sessionRepository.Object, willRepository.Object, senderFlow.Object);
 

--- a/src/Tests/Flows/DisconnectFlowSpec.cs
+++ b/src/Tests/Flows/DisconnectFlowSpec.cs
@@ -27,8 +27,8 @@ namespace Tests.Flows
 			var session = new ClientSession (clientId, clean: true);
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (c => c == clientId)))
-				.Returns (channel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (c => c == clientId)))
+				.Returns (Task.FromResult(channel.Object));
 
 			sessionRepository.Setup(r => r.Read(It.IsAny<string>())).Returns(session);
 
@@ -55,8 +55,8 @@ namespace Tests.Flows
 			var session = new ClientSession(clientId, clean: false);
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (c => c == clientId)))
-				.Returns (channel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (c => c == clientId)))
+				.Returns (Task.FromResult(channel.Object));
 
 			sessionRepository.Setup(r => r.Read(It.IsAny<string>())).Returns(session);
 

--- a/src/Tests/Flows/PublishReceiverFlowSpec.cs
+++ b/src/Tests/Flows/PublishReceiverFlowSpec.cs
@@ -75,11 +75,11 @@ namespace Tests.Flows
 			sessionRepository.Setup (r => r.ReadAll ()).Returns (sessions.AsQueryable());
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (s => s == subscribedClientId1)))
-				.Returns (client1Channel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (s => s == subscribedClientId1)))
+				.Returns (Task.FromResult(client1Channel.Object));
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (s => s == subscribedClientId2)))
-				.Returns (client2Channel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (s => s == subscribedClientId2)))
+				.Returns (Task.FromResult(client2Channel.Object));
 
 			var publish = new Publish (topic, MqttQualityOfService.AtMostOnce, retain: false, duplicated: false);
 
@@ -149,8 +149,8 @@ namespace Tests.Flows
 			sessionRepository.Setup (r => r.ReadAll ()).Returns ( sessions.AsQueryable());
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (s => s == subscribedClientId)))
-				.Returns (clientChannel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (s => s == subscribedClientId)))
+				.Returns (Task.FromResult(clientChannel.Object));
 
 			var packetId = (ushort?)new Random ().Next (0, ushort.MaxValue);
 			var publish = new Publish (topic, MqttQualityOfService.AtLeastOnce, retain: false, duplicated: false, packetId: packetId);
@@ -222,8 +222,8 @@ namespace Tests.Flows
 			sessionRepository.Setup (r => r.ReadAll ()).Returns ( sessions.AsQueryable());
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (s => s == subscribedClientId)))
-				.Returns (clientChannel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (s => s == subscribedClientId)))
+				.Returns (Task.FromResult(clientChannel.Object));
 
 			var publish = new Publish (topic, MqttQualityOfService.ExactlyOnce, retain: false, duplicated: false, packetId: packetId);
 
@@ -493,8 +493,8 @@ namespace Tests.Flows
 			sessionRepository.Setup (r => r.ReadAll ()).Returns (sessions.AsQueryable());
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (s => s == subscribedClientId)))
-				.Returns (clientChannel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (s => s == subscribedClientId)))
+				.Returns (Task.FromResult(clientChannel.Object));
 
 			var packetId = (ushort?)new Random ().Next (0, ushort.MaxValue);
 			var publish = new Publish (topic, MqttQualityOfService.ExactlyOnce, retain: false, duplicated: false, packetId: packetId);
@@ -617,8 +617,8 @@ namespace Tests.Flows
 			sessionRepository.Setup (r => r.ReadAll ()).Returns ( sessions.AsQueryable());
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (s => s == subscribedClientId)))
-				.Returns (clientChannel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (s => s == subscribedClientId)))
+				.Returns (Task.FromResult(clientChannel.Object));
 
 			var packetId = (ushort?)new Random ().Next (0, ushort.MaxValue);
 			var publish = new Publish (topic, MqttQualityOfService.ExactlyOnce, retain: false, duplicated: false, packetId: packetId);
@@ -694,8 +694,8 @@ namespace Tests.Flows
 			sessionRepository.Setup (r => r.ReadAll ()).Returns ( sessions.AsQueryable());
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (s => s == subscribedClientId)))
-				.Returns (clientChannel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (s => s == subscribedClientId)))
+				.Returns (Task.FromResult(clientChannel.Object));
 
 			var packetId = (ushort?)new Random ().Next (0, ushort.MaxValue);
 			var publish = new Publish (topic, MqttQualityOfService.ExactlyOnce, retain: false, duplicated: false, packetId: packetId);

--- a/src/Tests/Flows/PublishSenderFlowSpec.cs
+++ b/src/Tests/Flows/PublishSenderFlowSpec.cs
@@ -50,7 +50,7 @@ namespace Tests.Flows
 				.Callback<IPacket> (packet => sender.OnNext (packet))
 				.Returns (Task.Delay (0));
 
-			connectionProvider.Setup (m => m.GetConnection (It.IsAny<string> ())).Returns (channel.Object);
+			connectionProvider.Setup (m => m.GetConnectionAsync (It.IsAny<string> ())).Returns (Task.FromResult(channel.Object));
 
 			var retrySignal = new ManualResetEventSlim (initialState: false);
 			var retries = 0;
@@ -110,7 +110,7 @@ namespace Tests.Flows
 				.Callback<IPacket> (packet => sender.OnNext (packet))
 				.Returns (Task.Delay (0));
 
-			connectionProvider.Setup (m => m.GetConnection (It.IsAny<string> ())).Returns (channel.Object);
+			connectionProvider.Setup (m => m.GetConnectionAsync (It.IsAny<string> ())).Returns (Task.FromResult(channel.Object));
 
 			var retrySignal = new ManualResetEventSlim (initialState: false);
 			var retries = 0;
@@ -166,7 +166,7 @@ namespace Tests.Flows
 				.Callback<IPacket> (packet => sender.OnNext (packet))
 				.Returns (Task.Delay (0));
 
-			connectionProvider.Setup (m => m.GetConnection (It.Is<string> (s => s == clientId))).Returns (channel.Object);
+			connectionProvider.Setup (m => m.GetConnectionAsync (It.Is<string> (s => s == clientId))).Returns (Task.FromResult(channel.Object));
 
 			var ackSentSignal = new ManualResetEventSlim (initialState: false);
 
@@ -215,7 +215,7 @@ namespace Tests.Flows
 				.Callback<IPacket> (packet => sender.OnNext (packet))
 				.Returns (Task.Delay (0));
 
-			connectionProvider.Setup (m => m.GetConnection (It.Is<string> (s => s == clientId))).Returns (channel.Object);
+			connectionProvider.Setup (m => m.GetConnectionAsync (It.Is<string> (s => s == clientId))).Returns (Task.FromResult(channel.Object));
 
 			var ackSentSignal = new ManualResetEventSlim (initialState: false);
 

--- a/src/Tests/Flows/SubscribeFlowSpec.cs
+++ b/src/Tests/Flows/SubscribeFlowSpec.cs
@@ -52,8 +52,8 @@ namespace Tests.Flows
 			var connectionProvider = new Mock<IConnectionProvider> ();
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (c => c == clientId)))
-				.Returns (channel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (c => c == clientId)))
+				.Returns (Task.FromResult(channel.Object));
 
 			var flow = new ServerSubscribeFlow (topicEvaluator.Object, sessionRepository.Object, 
 				retainedMessageRepository, packetIdProvider, senderFlow, configuration);
@@ -112,8 +112,8 @@ namespace Tests.Flows
 			var connectionProvider = new Mock<IConnectionProvider> ();
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (c => c == clientId)))
-				.Returns (channel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (c => c == clientId)))
+				.Returns (Task.FromResult(channel.Object));
 
 			var flow = new ServerSubscribeFlow (topicEvaluator.Object,  sessionRepository.Object, 
 				retainedMessageRepository, packetIdProvider,
@@ -168,8 +168,8 @@ namespace Tests.Flows
 			var connectionProvider = new Mock<IConnectionProvider> ();
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (c => c == clientId)))
-				.Returns (channel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (c => c == clientId)))
+				.Returns (Task.FromResult(channel.Object));
 
 			var flow = new ServerSubscribeFlow (topicEvaluator.Object, sessionRepository.Object, 
 				retainedMessageRepository, packetIdProvider,
@@ -226,8 +226,8 @@ namespace Tests.Flows
 			var connectionProvider = new Mock<IConnectionProvider> ();
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (c => c == clientId)))
-				.Returns (channel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (c => c == clientId)))
+				.Returns (Task.FromResult(channel.Object));
 
 			var flow = new ServerSubscribeFlow (topicEvaluator.Object, 
 				sessionRepository.Object, retainedMessageRepository.Object,

--- a/src/Tests/Flows/UnsubscribeFlowSpec.cs
+++ b/src/Tests/Flows/UnsubscribeFlowSpec.cs
@@ -44,8 +44,8 @@ namespace Tests.Flows
 			var connectionProvider = new Mock<IConnectionProvider> ();
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (c => c == clientId)))
-				.Returns (channel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (c => c == clientId)))
+				.Returns (Task.FromResult(channel.Object));
 
 			var flow = new ServerUnsubscribeFlow (sessionRepository.Object);
 
@@ -84,8 +84,8 @@ namespace Tests.Flows
 			var connectionProvider = new Mock<IConnectionProvider> ();
 
 			connectionProvider
-				.Setup (p => p.GetConnection (It.Is<string> (c => c == clientId)))
-				.Returns (channel.Object);
+				.Setup (p => p.GetConnectionAsync (It.Is<string> (c => c == clientId)))
+				.Returns (Task.FromResult(channel.Object));
 
 			var flow = new ServerUnsubscribeFlow (sessionRepository.Object);
 

--- a/src/Tests/PacketListenerSpec.cs
+++ b/src/Tests/PacketListenerSpec.cs
@@ -90,7 +90,7 @@ namespace Tests
 
 			receiver.OnNext (connect);
 
-			connectionProvider.Verify (m => m.AddConnection (It.Is<string> (s => s == clientId), It.Is<IMqttChannel<IPacket>> (c => c == packetChannel.Object)));
+			connectionProvider.Verify (m => m.AddConnectionAsync (It.Is<string> (s => s == clientId), It.Is<IMqttChannel<IPacket>> (c => c == packetChannel.Object)));
 		}
 
 		[Fact]
@@ -187,7 +187,7 @@ namespace Tests
 		{
 			var connectionProvider = new Mock<IConnectionProvider> ();
 
-			connectionProvider.Setup (p => p.RemoveConnection (It.IsAny<string> ()));
+			connectionProvider.Setup (p => p.RemoveConnectionAsync (It.IsAny<string> ())).Returns(Task.CompletedTask);
 
             var serverPublishReceiverFlow = new Mock<IServerPublishReceiverFlow>();
             var flowProvider = new Mock<IProtocolFlowProvider> ();
@@ -219,7 +219,7 @@ namespace Tests
 			var errorOccured = errorSignal.Wait (TimeSpan.FromSeconds(1));
 
 			Assert.True (errorOccured);
-			connectionProvider.Verify (p => p.RemoveConnection (It.Is<string> (s => s == clientId)));
+			connectionProvider.Verify (p => p.RemoveConnectionAsync (It.Is<string> (s => s == clientId)));
 		}
 
 		[Fact]

--- a/src/Tests/PrivateChannelSpec.cs
+++ b/src/Tests/PrivateChannelSpec.cs
@@ -84,13 +84,13 @@ namespace Tests
         }
 
         [Fact]
-        public void when_disposing_channel_then_became_disconnected ()
+        public async Task when_disposing_channel_then_became_disconnected ()
         {
             var configuration = new MqttConfiguration ();
             var stream = new PrivateStream (configuration);
             var channel = new PrivateChannel (stream, EndpointIdentifier.Server, configuration);
 
-            channel.Dispose ();
+            await channel.CloseAsync ();
 
             Assert.False (channel.IsConnected);
         }

--- a/src/Tests/ServerSpec.cs
+++ b/src/Tests/ServerSpec.cs
@@ -128,7 +128,7 @@ namespace Tests
 
 			server.Stop ();
 
-			packetChannel.Verify (x => x.Dispose ());
+			packetChannel.Verify (x => x.CloseAsync ());
 		}
 
 		[Fact]
@@ -181,7 +181,7 @@ namespace Tests
 
             await Task.Delay (TimeSpan.FromMilliseconds (1000));
 
-            packetChannel.Verify (x => x.Dispose ());
+            packetChannel.Verify (x => x.CloseAsync ());
 		}
 	}
 }


### PR DESCRIPTION
- Removed IDisposable and added a CloseAsync method instead, with concurrency control with the SendAsync operation
- Fixed Rx subscriptions to be real async
- Adapted existing code to internal API changes
- Adapted tests to internal API changes