### PR TITLE
Add ClientId support for the '@' and '_' symbols.

### DIFF
--- a/src/Client/Sdk/Formatters/ConnectFormatter.cs
+++ b/src/Client/Sdk/Formatters/ConnectFormatter.cs
@@ -231,7 +231,7 @@ namespace System.Net.Mqtt.Sdk.Formatters
 			if (string.IsNullOrEmpty (clientId))
 				return true;
 
-			var regex = new Regex ("^[a-zA-Z0-9]+$");
+			var regex = new Regex ("^[a-zA-Z0-9_@]+$");
 
 			return regex.IsMatch (clientId);
 		}


### PR DESCRIPTION
Because Aliyun's MQTT server requires that the ClientId must contain the '@' and '_' symbols, the verification rule of the ClientId are adjusted.