### PR TITLE
Allow MqttServer to be created fully in memory without using TCP as the transport protocol by default

### DIFF
--- a/src/IntegrationTests/Context/IntegrationContext.cs
+++ b/src/IntegrationTests/Context/IntegrationContext.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Mqtt;
+using System.Net.Mqtt.Sdk.Bindings;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 
@@ -41,7 +42,7 @@ namespace IntegrationTests.Context
 			{
 				LoadConfiguration();
 
-				var server = MqttServer.Create(Configuration, authenticationProvider: authenticationProvider);
+				var server = MqttServer.Create(Configuration, new ServerTcpBinding(), authenticationProvider: authenticationProvider);
 
 				server.Start();
 

--- a/src/IntegrationTests/PrivateClientSpec.cs
+++ b/src/IntegrationTests/PrivateClientSpec.cs
@@ -1,7 +1,6 @@
 ﻿using IntegrationTests.Context;
 using IntegrationTests.Messages;
 using System;
-using System.Linq;
 using System.Net.Mqtt;
 using System.Threading.Tasks;
 using Xunit;
@@ -26,6 +25,20 @@ namespace IntegrationTests
 			Assert.True(client.IsConnected);
 			Assert.False(string.IsNullOrEmpty(client.Id));
 			Assert.StartsWith("private", client.Id);
+
+			client.Dispose();
+		}
+
+		[Fact]
+		public async Task when_creating_in_process_client_with_custom_id_then_it_is_already_connected()
+		{
+			var clientId = "fooClient";
+			var client = await server.CreateClientAsync(clientId);
+
+			Assert.NotNull(client);
+			Assert.True(client.IsConnected);
+			Assert.False(string.IsNullOrEmpty(client.Id));
+			Assert.Equal(clientId, client.Id);
 
 			client.Dispose();
 		}
@@ -204,6 +217,31 @@ namespace IntegrationTests
 
 			inProcessClient.Dispose();
 			remoteClient.Dispose();
+		}
+
+		[Fact]
+		public async Task when_creating_in_process_clients_with_in_memory_server_then_succeeds()
+		{
+			var inMemoryServer = MqttServer.CreateInMemory();
+
+			inMemoryServer.Start();
+
+			var client1 = await inMemoryServer.CreateClientAsync();
+			var clientId = "testClient";
+			var client2 = await inMemoryServer.CreateClientAsync(clientId);
+
+			Assert.NotNull(client1);
+			Assert.NotNull(client2);
+			Assert.True(client1.IsConnected);
+			Assert.True(client2.IsConnected);
+			Assert.False(string.IsNullOrEmpty(client1.Id));
+			Assert.False(string.IsNullOrEmpty(client2.Id));
+			Assert.StartsWith("private", client1.Id);
+			Assert.Equal(clientId, client2.Id);
+
+			client1.Dispose();
+			client2.Dispose();
+			inMemoryServer.Stop();
 		}
 
 		public void Dispose()

--- a/src/Server/IMqttConnectedClient.cs
+++ b/src/Server/IMqttConnectedClient.cs
@@ -4,8 +4,7 @@ using System.Threading.Tasks;
 namespace System.Net.Mqtt
 {
 	/// <summary>
-	/// Represents an <see cref="IMqttClient"/> that has already
-	/// performed the protocol connection
+	/// Represents an <see cref="IMqttClient"/> that uses an in-memory transport and that has already performed the protocol connection
 	/// This interface is only provided by the Server when creating in process clients
 	/// doing <see cref="IMqttServer.CreateClientAsync" />, since invoking the 
 	/// <see cref="IMqttClient.ConnectAsync(MqttClientCredentials, MqttLastWill, bool)"/> 

--- a/src/Server/IMqttServer.cs
+++ b/src/Server/IMqttServer.cs
@@ -58,12 +58,12 @@ namespace System.Net.Mqtt
 		void Start();
 
 		/// <summary>
-		/// Creates an in process client and establishes the protocol 
-		/// connection before returning it to the caller
+		/// Creates an in process client with an in-memory transport that establishes the protocol connection before returning it to the caller
 		/// See <see cref="IMqttConnectedClient" /> for more details about in process clients 
 		/// </summary>
+		/// <param name="clientId">Identifier of the client to create and connect. If null, a random id will be used</param>
 		/// <returns>Returns a connected client ready to use</returns>
-		Task<IMqttConnectedClient> CreateClientAsync();
+		Task<IMqttConnectedClient> CreateClientAsync(string clientId = null);
 
 		/// <summary>
 		/// Stops the server and disposes it.

--- a/src/Server/MqttServer.cs
+++ b/src/Server/MqttServer.cs
@@ -19,7 +19,6 @@ namespace System.Net.Mqtt
 		/// </param>
 		/// <param name="binding">
 		/// The binding to use as the underlying transport layer.
-		/// Deafault value: <see cref="ServerTcpBinding"/>
 		/// Possible values: <see cref="ServerTcpBinding"/>, <see cref="ServerWebSocketBinding"/>
 		/// See <see cref="IMqttServerBinding"/> for more details about how 
 		/// to implement a custom binding
@@ -32,26 +31,53 @@ namespace System.Net.Mqtt
 		/// </param>
 		/// <returns>A new MQTT Server</returns>
 		/// <exception cref="MqttServerException">MqttServerException</exception>
-		public static IMqttServer Create(MqttConfiguration configuration, IMqttServerBinding binding = null, IMqttAuthenticationProvider authenticationProvider = null)
-			=> new MqttServerFactory(binding ?? new ServerTcpBinding(), authenticationProvider).CreateServer(configuration);
+		public static IMqttServer Create(MqttConfiguration configuration, IMqttServerBinding binding, IMqttAuthenticationProvider authenticationProvider = null)
+			=> new MqttServerFactory(binding, authenticationProvider).CreateServer(configuration);
 
 		/// <summary>
-		/// Creates an <see cref="IMqttServer"/> over the TCP protocol, using the 
-		/// specified port.
+		/// Creates an <see cref="IMqttServer"/> using a TCP binding and a specified MQTT configuration.
+		/// </summary>
+		/// <param name="configuration">
+		/// The configuration used for creating the Server.
+		/// See <see cref="MqttConfiguration" /> for more details about the supported values.
+		/// </param>
+		/// <returns>A new MQTT Server</returns>
+		/// <exception cref="MqttServerException">MqttServerException</exception>
+		public static IMqttServer CreateTcp(MqttConfiguration configuration) => new MqttServerFactory(new ServerTcpBinding()).CreateServer(configuration);
+
+		/// <summary>
+		/// Creates an <see cref="IMqttServer"/> using a TCP binding and a specified port.
 		/// </summary>
 		/// <param name="port">
 		/// The port to listen for incoming connections.
 		/// </param>
 		/// <returns>A new MQTT Server</returns>
 		/// <exception cref="MqttServerException">MqttServerException</exception>
-		public static IMqttServer Create(int port) => new MqttServerFactory().CreateServer(new MqttConfiguration { Port = port });
+		public static IMqttServer CreateTcp(int port) => new MqttServerFactory(new ServerTcpBinding()).CreateServer(new MqttConfiguration { Port = port });
 
 		/// <summary>
-		/// Creates an <see cref="IMqttServer"/> over the TCP protocol, using the 
-		/// MQTT protocol defaults.
+		/// Creates an <see cref="IMqttServer"/> using a TCP binding and the MQTT protocol defaults.
 		/// </summary>
 		/// <returns>A new MQTT Server</returns>
 		/// <exception cref="MqttServerException">MqttServerException</exception>
-		public static IMqttServer Create() => new MqttServerFactory().CreateServer(new MqttConfiguration());
+		public static IMqttServer CreateTcp() => new MqttServerFactory(new ServerTcpBinding()).CreateServer(new MqttConfiguration());
+
+		/// <summary>
+		/// Creates an <see cref="IMqttServer"/> using an in-memory binding and a specified MQTT configuration.
+		/// </summary>
+		/// <param name="configuration">
+		/// The configuration used for creating the Server.
+		/// See <see cref="MqttConfiguration" /> for more details about the supported values.
+		/// </param>
+		/// <returns>A new MQTT Server</returns>
+		/// <exception cref="MqttServerException">MqttServerException</exception>
+		public static IMqttServer CreateInMemory(MqttConfiguration configuration) => new MqttServerFactory().CreateServer(configuration);
+
+		/// <summary>
+		/// Creates an <see cref="IMqttServer"/> using an in-memory binding and the MQTT protocol defaults.
+		/// </summary>
+		/// <returns>A new MQTT Server</returns>
+		/// <exception cref="MqttServerException">MqttServerException</exception>
+		public static IMqttServer CreateInMemory() => new MqttServerFactory().CreateServer(new MqttConfiguration());
 	}
 }

--- a/src/Server/Sdk/Bindings/EndpointIdentifier.cs
+++ b/src/Server/Sdk/Bindings/EndpointIdentifier.cs
@@ -1,0 +1,8 @@
+﻿namespace System.Net.Mqtt.Sdk.Bindings
+{
+	internal enum EndpointIdentifier
+	{
+		Server,
+		Client
+	}
+}

--- a/src/Server/Sdk/Bindings/IServerPrivateBinding.cs
+++ b/src/Server/Sdk/Bindings/IServerPrivateBinding.cs
@@ -1,0 +1,9 @@
+﻿using System.Reactive.Subjects;
+
+namespace System.Net.Mqtt.Sdk.Bindings
+{
+	internal interface IServerPrivateBinding : IMqttServerBinding
+	{
+		ISubject<PrivateStream> PrivateStreamListener { get; }
+	}
+}

--- a/src/Server/Sdk/Bindings/PrivateBinding.cs
+++ b/src/Server/Sdk/Bindings/PrivateBinding.cs
@@ -4,18 +4,17 @@ namespace System.Net.Mqtt.Sdk.Bindings
 {
 	internal class PrivateBinding : IMqttBinding
 	{
-		readonly ISubject<PrivateStream> privateStreamListener;
 		readonly EndpointIdentifier identifier;
 
 		public PrivateBinding(ISubject<PrivateStream> privateStreamListener, EndpointIdentifier identifier)
 		{
-			this.privateStreamListener = privateStreamListener;
 			this.identifier = identifier;
+			PrivateStreamListener = privateStreamListener;
 		}
 
+		public ISubject<PrivateStream> PrivateStreamListener { get; }
+
 		public IMqttChannelFactory GetChannelFactory(string hostAddress, MqttConfiguration configuration)
-		{
-			return new PrivateChannelFactory(privateStreamListener, identifier, configuration);
-		}
+			=> new PrivateChannelFactory(PrivateStreamListener, identifier, configuration);
 	}
 }

--- a/src/Server/Sdk/Bindings/PrivateStream.cs
+++ b/src/Server/Sdk/Bindings/PrivateStream.cs
@@ -3,12 +3,6 @@ using System.Reactive.Subjects;
 
 namespace System.Net.Mqtt.Sdk.Bindings
 {
-	internal enum EndpointIdentifier
-	{
-		Server,
-		Client
-	}
-
 	internal class PrivateStream : IDisposable
 	{
 		bool disposed;

--- a/src/Server/Sdk/Bindings/ServerPrivateBinding.cs
+++ b/src/Server/Sdk/Bindings/ServerPrivateBinding.cs
@@ -1,0 +1,14 @@
+﻿using System.Reactive.Subjects;
+
+namespace System.Net.Mqtt.Sdk.Bindings
+{
+	internal class ServerPrivateBinding : PrivateBinding, IServerPrivateBinding
+	{
+		public ServerPrivateBinding() : base(privateStreamListener: new Subject<PrivateStream>(), identifier: EndpointIdentifier.Server)
+		{
+		}
+
+		public IMqttChannelListener GetChannelListener(MqttConfiguration configuration)
+			=> new PrivateChannelListener(PrivateStreamListener, configuration);
+	}
+}

--- a/src/Tests/ServerSpec.cs
+++ b/src/Tests/ServerSpec.cs
@@ -1,12 +1,13 @@
 ﻿using Moq;
 using System;
 using System.Net.Mqtt;
+using System.Net.Mqtt.Sdk;
+using System.Net.Mqtt.Sdk.Bindings;
 using System.Net.Mqtt.Sdk.Flows;
 using System.Net.Mqtt.Sdk.Packets;
 using System.Reactive.Subjects;
 using System.Threading.Tasks;
 using Xunit;
-using System.Net.Mqtt.Sdk;
 
 namespace Tests
 {
@@ -15,6 +16,13 @@ namespace Tests
 		[Fact]
 		public void when_server_does_not_start_then_connections_are_ignored()
 		{
+			var configuration = Mock.Of<MqttConfiguration>(c => c.WaitTimeoutSecs == 60);
+			var channelFactory = new Mock<IMqttChannelFactory>();
+
+			channelFactory
+				.Setup(f => f.CreateAsync())
+				.ReturnsAsync(Mock.Of<IMqttChannel<byte[]>>());
+
 			var sockets = new Subject<IMqttChannel<byte[]>>();
 			var channelProvider = new Mock<IMqttChannelListener>();
 
@@ -22,7 +30,28 @@ namespace Tests
 				.Setup(p => p.GetChannelStream())
 				.Returns(sockets);
 
-			var configuration = Mock.Of<MqttConfiguration>(c => c.WaitTimeoutSecs == 60);
+			var binding = new Mock<IMqttServerBinding>();
+
+			binding
+				.Setup(b => b.GetChannelFactory(It.IsAny<string>(), It.Is<MqttConfiguration>(c => c == configuration)))
+				.Returns(channelFactory.Object);
+
+			binding
+				.Setup(b => b.GetChannelListener(It.Is<MqttConfiguration>(c => c == configuration)))
+				.Returns(channelProvider.Object);
+
+			var privateSockets = new Subject<IMqttChannel<byte[]>>();
+			var privateChannelProvider = new Mock<IMqttChannelListener>();
+
+			privateChannelProvider
+				.Setup(p => p.GetChannelStream())
+				.Returns(privateSockets);
+
+			var privateBinding = new Mock<IServerPrivateBinding>();
+
+			privateBinding
+				.Setup(b => b.GetChannelListener(It.Is<MqttConfiguration>(c => c == configuration)))
+				.Returns(privateChannelProvider.Object);
 
 			var packets = new Subject<IPacket>();
 			var packetChannel = new Mock<IMqttChannel<IPacket>>();
@@ -41,7 +70,7 @@ namespace Tests
 			var flowProvider = Mock.Of<IProtocolFlowProvider>();
 			var connectionProvider = new Mock<IConnectionProvider>();
 
-			var server = new MqttServerImpl(channelProvider.Object, factory, flowProvider, connectionProvider.Object, Mock.Of<ISubject<MqttUndeliveredMessage>>(), configuration);
+			var server = new MqttServerImpl(privateBinding.Object, factory, flowProvider, connectionProvider.Object, Mock.Of<ISubject<MqttUndeliveredMessage>>(), configuration, binding.Object);
 
 			sockets.OnNext(Mock.Of<IMqttChannel<byte[]>>(x => x.ReceiverStream == new Subject<byte[]>()));
 			sockets.OnNext(Mock.Of<IMqttChannel<byte[]>>(x => x.ReceiverStream == new Subject<byte[]>()));
@@ -53,6 +82,13 @@ namespace Tests
 		[Fact]
 		public void when_connection_established_then_active_connections_increases()
 		{
+			var configuration = Mock.Of<MqttConfiguration>(c => c.WaitTimeoutSecs == 60);
+			var channelFactory = new Mock<IMqttChannelFactory>();
+
+			channelFactory
+				.Setup(f => f.CreateAsync())
+				.ReturnsAsync(Mock.Of<IMqttChannel<byte[]>>());
+
 			var sockets = new Subject<IMqttChannel<byte[]>>();
 			var channelProvider = new Mock<IMqttChannelListener>();
 
@@ -60,7 +96,28 @@ namespace Tests
 				.Setup(p => p.GetChannelStream())
 				.Returns(sockets);
 
-			var configuration = Mock.Of<MqttConfiguration>(c => c.WaitTimeoutSecs == 60);
+			var binding = new Mock<IMqttServerBinding>();
+
+			binding
+				.Setup(b => b.GetChannelFactory(It.IsAny<string>(), It.Is<MqttConfiguration>(c => c == configuration)))
+				.Returns(channelFactory.Object);
+
+			binding
+				.Setup(b => b.GetChannelListener(It.Is<MqttConfiguration>(c => c == configuration)))
+				.Returns(channelProvider.Object);
+
+			var privateSockets = new Subject<IMqttChannel<byte[]>>();
+			var privateChannelProvider = new Mock<IMqttChannelListener>();
+
+			privateChannelProvider
+				.Setup(p => p.GetChannelStream())
+				.Returns(privateSockets);
+
+			var privateBinding = new Mock<IServerPrivateBinding>();
+
+			privateBinding
+				.Setup(b => b.GetChannelListener(It.Is<MqttConfiguration>(c => c == configuration)))
+				.Returns(privateChannelProvider.Object);
 
 			var packets = new Subject<IPacket>();
 			var packetChannel = new Mock<IMqttChannel<IPacket>>();
@@ -79,7 +136,7 @@ namespace Tests
 			var flowProvider = Mock.Of<IProtocolFlowProvider>();
 			var connectionProvider = new Mock<IConnectionProvider>();
 
-			var server = new MqttServerImpl(channelProvider.Object, factory, flowProvider, connectionProvider.Object, Mock.Of<ISubject<MqttUndeliveredMessage>>(), configuration);
+			var server = new MqttServerImpl(privateBinding.Object, factory, flowProvider, connectionProvider.Object, Mock.Of<ISubject<MqttUndeliveredMessage>>(), configuration, binding.Object);
 
 			server.Start();
 
@@ -91,14 +148,91 @@ namespace Tests
 		}
 
 		[Fact]
+		public void when_using_in_memory_server_and_connection_established_then_active_connections_increases()
+		{
+			var configuration = Mock.Of<MqttConfiguration>(c => c.WaitTimeoutSecs == 60);
+
+			var privateSockets = new Subject<IMqttChannel<byte[]>>();
+			var privateChannelProvider = new Mock<IMqttChannelListener>();
+
+			privateChannelProvider
+				.Setup(p => p.GetChannelStream())
+				.Returns(privateSockets);
+
+			var privateBinding = new Mock<IServerPrivateBinding>();
+
+			privateBinding
+				.Setup(b => b.GetChannelListener(It.Is<MqttConfiguration>(c => c == configuration)))
+				.Returns(privateChannelProvider.Object);
+
+			var packets = new Subject<IPacket>();
+			var packetChannel = new Mock<IMqttChannel<IPacket>>();
+			var factory = Mock.Of<IPacketChannelFactory>(x => x.Create(It.IsAny<IMqttChannel<byte[]>>()) == packetChannel.Object);
+
+			packetChannel
+				.Setup(c => c.IsConnected)
+				.Returns(true);
+			packetChannel
+				.Setup(c => c.SenderStream)
+				.Returns(new Subject<IPacket>());
+			packetChannel
+				.Setup(c => c.ReceiverStream)
+				.Returns(packets);
+
+			var flowProvider = Mock.Of<IProtocolFlowProvider>();
+			var connectionProvider = new Mock<IConnectionProvider>();
+
+			var server = new MqttServerImpl(privateBinding.Object, factory, flowProvider, connectionProvider.Object, 
+				Mock.Of<ISubject<MqttUndeliveredMessage>>(), configuration, binding: null);
+
+			server.Start();
+
+			privateSockets.OnNext(Mock.Of<IMqttChannel<byte[]>>(x => x.ReceiverStream == new Subject<byte[]>()));
+			privateSockets.OnNext(Mock.Of<IMqttChannel<byte[]>>(x => x.ReceiverStream == new Subject<byte[]>()));
+			privateSockets.OnNext(Mock.Of<IMqttChannel<byte[]>>(x => x.ReceiverStream == new Subject<byte[]>()));
+
+			Assert.Equal(3, server.ActiveConnections);
+		}
+
+		[Fact]
 		public void when_server_closed_then_pending_connection_is_closed()
 		{
+			var configuration = Mock.Of<MqttConfiguration>(c => c.WaitTimeoutSecs == 60);
+			var channelFactory = new Mock<IMqttChannelFactory>();
+
+			channelFactory
+				.Setup(f => f.CreateAsync())
+				.ReturnsAsync(Mock.Of<IMqttChannel<byte[]>>());
+
 			var sockets = new Subject<IMqttChannel<byte[]>>();
 			var channelProvider = new Mock<IMqttChannelListener>();
 
 			channelProvider
 				.Setup(p => p.GetChannelStream())
 				.Returns(sockets);
+
+			var binding = new Mock<IMqttServerBinding>();
+
+			binding
+				.Setup(b => b.GetChannelFactory(It.IsAny<string>(), It.Is<MqttConfiguration>(c => c == configuration)))
+				.Returns(channelFactory.Object);
+
+			binding
+				.Setup(b => b.GetChannelListener(It.Is<MqttConfiguration>(c => c == configuration)))
+				.Returns(channelProvider.Object);
+
+			var privateSockets = new Subject<IMqttChannel<byte[]>>();
+			var privateChannelProvider = new Mock<IMqttChannelListener>();
+
+			privateChannelProvider
+				.Setup(p => p.GetChannelStream())
+				.Returns(privateSockets);
+
+			var privateBinding = new Mock<IServerPrivateBinding>();
+
+			privateBinding
+				.Setup(b => b.GetChannelListener(It.Is<MqttConfiguration>(c => c == configuration)))
+				.Returns(privateChannelProvider.Object);
 
 			var packetChannel = new Mock<IMqttChannel<IPacket>>();
 
@@ -115,10 +249,8 @@ namespace Tests
 			var flowProvider = Mock.Of<IProtocolFlowProvider>();
 			var connectionProvider = new Mock<IConnectionProvider>();
 
-			var configuration = Mock.Of<MqttConfiguration>(c => c.WaitTimeoutSecs == 60);
-
-			var server = new MqttServerImpl(channelProvider.Object, Mock.Of<IPacketChannelFactory>(x => x.Create(It.IsAny<IMqttChannel<byte[]>>()) == packetChannel.Object),
-				flowProvider, connectionProvider.Object, Mock.Of<ISubject<MqttUndeliveredMessage>>(), configuration);
+			var server = new MqttServerImpl(privateBinding.Object, Mock.Of<IPacketChannelFactory>(x => x.Create(It.IsAny<IMqttChannel<byte[]>>()) == packetChannel.Object),
+				flowProvider, connectionProvider.Object, Mock.Of<ISubject<MqttUndeliveredMessage>>(), configuration, binding.Object);
 
 			server.Start();
 
@@ -134,6 +266,13 @@ namespace Tests
 		[Fact]
 		public async Task when_receiver_error_then_closes_connection()
 		{
+			var configuration = Mock.Of<MqttConfiguration>(c => c.WaitTimeoutSecs == 60);
+			var channelFactory = new Mock<IMqttChannelFactory>();
+
+			channelFactory
+				.Setup(f => f.CreateAsync())
+				.ReturnsAsync(Mock.Of<IMqttChannel<byte[]>>());
+
 			var sockets = new Subject<IMqttChannel<byte[]>>();
 			var channelProvider = new Mock<IMqttChannelListener>();
 
@@ -141,7 +280,28 @@ namespace Tests
 				.Setup(p => p.GetChannelStream())
 				.Returns(sockets);
 
-			var configuration = Mock.Of<MqttConfiguration>(c => c.WaitTimeoutSecs == 60);
+			var binding = new Mock<IMqttServerBinding>();
+
+			binding
+				.Setup(b => b.GetChannelFactory(It.IsAny<string>(), It.Is<MqttConfiguration>(c => c == configuration)))
+				.Returns(channelFactory.Object);
+
+			binding
+				.Setup(b => b.GetChannelListener(It.Is<MqttConfiguration>(c => c == configuration)))
+				.Returns(channelProvider.Object);
+
+			var privateSockets = new Subject<IMqttChannel<byte[]>>();
+			var privateChannelProvider = new Mock<IMqttChannelListener>();
+
+			privateChannelProvider
+				.Setup(p => p.GetChannelStream())
+				.Returns(privateSockets);
+
+			var privateBinding = new Mock<IServerPrivateBinding>();
+
+			privateBinding
+				.Setup(b => b.GetChannelListener(It.Is<MqttConfiguration>(c => c == configuration)))
+				.Returns(privateChannelProvider.Object);
 
 			var packets = new Subject<IPacket>();
 
@@ -164,7 +324,7 @@ namespace Tests
 			var flowProvider = Mock.Of<IProtocolFlowProvider>();
 			var connectionProvider = new Mock<IConnectionProvider>();
 
-			var server = new MqttServerImpl(channelProvider.Object, factory.Object, flowProvider, connectionProvider.Object, Mock.Of<ISubject<MqttUndeliveredMessage>>(), configuration);
+			var server = new MqttServerImpl(privateBinding.Object, factory.Object, flowProvider, connectionProvider.Object, Mock.Of<ISubject<MqttUndeliveredMessage>>(), configuration, binding.Object);
 			var receiver = new Subject<byte[]>();
 			var socket = new Mock<IMqttChannel<byte[]>>();
 


### PR DESCRIPTION
When creating in-memory MQTT servers, the clients can only be created through the `IMqttServer.CreateClientAsync` method.

The System.Net.Mqtt client library will not be able to connect to any MQTT in-memory server by design.

This happens because in-memory MQTT servers are meant to be used together with clients in the same process so using the server library is enough to create clients already connected to that server

Sample code:

```
var server = MqttServer.CreateInMemory();

server.Start();

var client1 = await server.CreateClientAsync();
var client2 = await server.CreateClientAsync(clientId: "foo");

```