### PR TITLE
Upgrade to Newtonsoft.Json 13.0.2

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -15,7 +15,7 @@
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.msbuild" Version="2.4.1" />
 		<PackageReference Include="Moq" Version="*" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
 	</ItemGroup>
 
 	<PropertyGroup Condition="'$(GitInfoImported)' == 'true'">


### PR DESCRIPTION
Fixes [Bug 1696653](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1696653): [Component Governance Alert] - GHSA-5crp-9r3c-p9vr in Newtonsoft.Json 13.0.1. Severity: High - xamarin/mqtt
[AB#1696653](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1696653)