### PR TITLE
Bump System.Diagnostics.Tracer to 2.1.0-alpha

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -4,7 +4,7 @@
 	<!-- Common Packages -->
 	<ItemGroup>
 		<PackageReference Include="GitInfo" Version="2.3.0" PrivateAssets="all" />
-		<PackageReference Include="System.Diagnostics.Tracer" Version="2.0.8" />
+		<PackageReference Include="System.Diagnostics.Tracer" Version="2.1.0-alpha" />
 		<PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
 		<PackageReference Include="System.Reactive" Version="5.0.0" />
 		<PackageReference Include="NuGetizer" Version="1.0.4" />


### PR DESCRIPTION
## Description
We need to bump `System.Diagnostics.Tracer` to `2.1.0-alpha` so that XamarinVS can pass BinSkim. See https://github.com/xamarin/XamarinVS/pull/13847 for more info.

## PR Checklist
- [x] Title is meaningful
- [x] Work Item is linked
- [x] Changes are described

- **Tests**
  - [ ] Automated tests are added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] N/A - Just a dependency bump
  - **OR**
  - [ ] Upcoming sprint Work Item: <!-- link -->
  - **OR**
  - [ ] Test exception <!-- include short explanation -->
