### PR TITLE
Fix Newtonsoft.JSon version to 13.0.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,8 @@ updates:
       # https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1867849
       - dependency-name: "Moq"
         versions: [">4.18.4"]
+      - dependency-name: "Newtonsoft.JSon"
+        versions: [">13.0.3"]
 
   - package-ecosystem: gitsubmodule
     directory: "/"


### PR DESCRIPTION
## Description
Updating dependabot rules to make Newtonsoft.JSon stay at 13.0.3.

## PR Checklist
- [x] Title is meaningful
- [ ] Work Item is linked
- [x] Changes are described

- **Tests**
  - [ ] Automated tests are added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] N/A: infrastructure
  - **OR**
  - [ ] Upcoming sprint Work Item: <!-- link -->
  - **OR**
  - [ ] Test exception <!-- include short explanation -->
