### PR TITLE
Increasing build stage timeout after 1ES template changes

### DIFF
--- a/build/stages/build.yml
+++ b/build/stages/build.yml
@@ -4,7 +4,7 @@ stages:
 - stage: Build
   jobs:
   - job: Windows
-    timeoutInMinutes: 20
+    timeoutInMinutes: 60
     pool:
       name: VSEngSS-MicroBuild2022-1ES
     templateContext:


### PR DESCRIPTION
## Description
After the 1ES template conversion the build stage has a lot more steps.  The existing 20 minute timeout was good enough for PR builds, but CI builds need more time.

## PR Checklist
- [x] Title is meaningful
- [ ] Work Item is linked
- [x] Changes are described

- **Tests**
  - [ ] Automated tests are added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] N/A: Infrastructure
  - **OR**
  - [ ] Upcoming sprint Work Item: <!-- link -->
  - **OR**
  - [ ] Test exception <!-- include short explanation -->
