### PR TITLE
Fix SDL analysis pool

### DIFF
--- a/build/variables.yml
+++ b/build/variables.yml
@@ -12,7 +12,7 @@ variables:
 - name: WindowsEOPoolName
   value: AzurePipelines-EO
 - name: WindowsImageOverride
-  value: AzurePipelinesWindows2022compliantGPT
+  value: 1ESPT-Windows2022
 - name: WindowsPoolName
   value: VSEngSS-MicroBuild2022-1ES
 - name: Configuration

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -39,7 +39,7 @@ extends:
       sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
     pool:
       name: AzurePipelines-EO
-      image: AzurePipelinesWindows2022compliantGPT
+      image: 1ESPT-Windows2022
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling


### PR DESCRIPTION
## Description
The original image VSEng provided has some issues with the auto-baselining task. It will eventually be deprecated, so we're switching to the new image: 1ESPT-Windows2022
