### PR TITLE
Enable xml documentation using GenerateDocumentationFile=true

### DIFF
--- a/src/Client/Client.csproj
+++ b/src/Client/Client.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <AssemblyName>System.Net.Mqtt</AssemblyName>
     <RootNamespace>System.Net.Mqtt</RootNamespace>
-    <DocumentationFile>$(IntermediateOutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Server/Server.csproj
+++ b/src/Server/Server.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <AssemblyName>System.Net.Mqtt.Server</AssemblyName>
     <RootNamespace>System.Net.Mqtt.Server</RootNamespace>
-    <DocumentationFile>$(IntermediateOutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Using IntermediateOutputPath to set DocumentationFile doesn't work in .NET 8:

    CSC : error CS0016: Could not write to output file '/net472/System.Net.Mqtt.xml' -- 'Could not find a part of the path '/net472/System.Net.Mqtt.xml'.'
    CSC : error CS0016: Could not write to output file '/netstandard2.0/System.Net.Mqtt.xml' -- 'Could not find a part of the path '/netstandard2.0/System.Net.Mqtt.xml'.'

So just set GenerateDocumentationFile=true instead, and then the build will
automatically choose an appropriate path.

## PR Checklist

- [x] Title is meaningful
- [ ] Work Item is linked N/A
- [x] Changes are described