### PR TITLE
Enable symbols publishing for the mqtt binaries

### DIFF
--- a/build/stages/build.yml
+++ b/build/stages/build.yml
@@ -1,5 +1,9 @@
 # Build Stage
 
+parameters:
+- name: PublishSymbols
+  type: boolean
+
 stages:
 - stage: Build
   jobs:
@@ -119,3 +123,34 @@ stages:
         FlattenFolders: true
         OverWrite: true # Check if we should copy to $(TargetFramework) subfolders instead
       condition: always()
+
+    # Set variable to publish symbols to symbol server if we are on main or release branches, or if the parameter is set
+    - powershell: |
+        $publishSymbols = '${{ parameters.PublishSymbols }}'
+
+        if ($publishSymbols -eq 'false') {
+          $branch = '$(Build.SourceBranch)'
+          $isRelease = '$(Xamarin.IsRelease)'
+        
+          if($branch -eq '$(MainBranch)' -or $isRelease -eq 'true') {
+            $publishSymbols = 'true'
+          }
+        }
+
+        Write-Host "Publish Symbols: $publishSymbols"
+        Write-Host "##vso[task.setvariable variable=Xamarin.PublishSymbols]$publishSymbols"
+      name: 'SetPublishSymbols'
+      displayName: 'Evaluate Publish Symbols'
+
+    # See: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/671/Manage-Your-Symbols
+    # For more details on how to publish symbols to the symbol server
+    - task: PublishSymbols@2
+      inputs:
+        SymbolsFolder: $(Build.ArtifactStagingDirectory)/Symbols
+        SearchPattern: '**\*.pdb'
+        SymbolServerType: TeamServices
+        ArtifactServices.Symbol.AccountName: devdiv
+        ArtifactServices.Symbol.PAT: $(System.AccessToken)
+        ArtifactServices.Symbol.UseAAD: false
+      displayName: Publish Symbols to Symbol Server
+      condition: and(succeeded(), eq(variables['Xamarin.PublishSymbols'], 'true'))

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -20,6 +20,12 @@ trigger:
 pr:
   - main
 
+parameters:
+- name: PublishSymbols
+  displayName: Publish Symbols to Symbol Server
+  type: boolean
+  default: false
+
 variables:
 - template: build/variables.yml
 extends:
@@ -45,5 +51,7 @@ extends:
     - ES365AIMigrationTooling
     stages:
     - template: build/stages/build.yml
+      parameters:
+        PublishSymbols: ${{ parameters.PublishSymbols }}
     - template: build/stages/test.yml
     - template: build/stages/package.yml


### PR DESCRIPTION
Publishing symbols is now a 1CS requirement: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2015459

We are publishing pdbs for the mqtt assemblies for main and release branches. We are also adding a parameter in the pipeline to publish symbols on demand for other branches as well

More info about how to publish symbols: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/671/Manage-Your-Symbols

## Description
<!-- Add details about the changes. Include any information that would help others review effectively. When appropriate, add a demo or before/after details. -->

## PR Checklist
- [ ] Title is meaningful
- [ ] Work Item is linked
- [ ] Changes are described

- **Tests**
  - [ ] Automated tests are added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] N/A <!-- infrastructure, documentation etc. -->
  - **OR**
  - [ ] Upcoming sprint Work Item: <!-- link -->
  - **OR**
  - [ ] Test exception <!-- include short explanation -->
