### PR TITLE
Enabling Code Sign Validation through 1ES template

### DIFF
--- a/build/sign-verify-ignore.txt
+++ b/build/sign-verify-ignore.txt
@@ -1,1 +1,0 @@
-**\*.xml,ignore unsigned xml

--- a/build/sign-verify-ignore.txt
+++ b/build/sign-verify-ignore.txt
@@ -1,0 +1,1 @@
+**\*.xml,ignore unsigned xml

--- a/build/stages/build.yml
+++ b/build/stages/build.yml
@@ -100,6 +100,13 @@ stages:
         msbuildArguments: /t:Build /p:_SignFiles=true /noautoresponse /bl:"$(Build.ArtifactStagingDirectory)\binlogs\build.binlog"
       condition: always()
 
+    - task: MicroBuildCodesignVerify@3
+      displayName: 'Verify Signed Files'
+      inputs:
+        TargetFolders: $(System.DefaultWorkingDirectory)\pack
+        ExcludeSNVerify: true
+        ApprovalListPathForCerts: $(Build.SourcesDirectory)\build\sign-verify-ignore.txt
+
     - task: CopyFiles@2
       displayName: 'Copy Symbols'
       inputs:

--- a/build/stages/build.yml
+++ b/build/stages/build.yml
@@ -100,13 +100,6 @@ stages:
         msbuildArguments: /t:Build /p:_SignFiles=true /noautoresponse /bl:"$(Build.ArtifactStagingDirectory)\binlogs\build.binlog"
       condition: always()
 
-    - task: MicroBuildCodesignVerify@3
-      displayName: 'Verify Signed Files'
-      inputs:
-        TargetFolders: $(System.DefaultWorkingDirectory)\pack
-        ExcludeSNVerify: true
-        ApprovalListPathForCerts: $(Build.SourcesDirectory)\build\sign-verify-ignore.txt
-
     - task: CopyFiles@2
       displayName: 'Copy Symbols'
       inputs:

--- a/build/stages/build.yml
+++ b/build/stages/build.yml
@@ -20,24 +20,28 @@ stages:
         targetPath: '$(Build.SourcesDirectory)\src\Tests\bin\$(Configuration)'
         artifactName: unit-tests
         sbomEnabled: false
+        codeSignValidationEnabled: false
       - output: pipelineArtifact
         displayName: 'Publish Artifact: integration-tests'
         condition: always()
         targetPath: '$(Build.SourcesDirectory)\src\IntegrationTests\bin\$(Configuration)'
         artifactName: integration-tests
         sbomEnabled: false
+        codeSignValidationEnabled: false
       - output: pipelineArtifact
         displayName: 'Publish Artifact: logs'
         condition: always()
         targetPath: '$(Build.ArtifactStagingDirectory)\binlogs'
         artifactName: logs
         sbomEnabled: false
+        codeSignValidationEnabled: false
       - output: pipelineArtifact
         displayName: 'Publish Artifact: symbols'
         condition: always()
         targetPath: '$(Build.ArtifactStagingDirectory)/Symbols'
         artifactName: symbols
         sbomEnabled: false
+        codeSignValidationEnabled: false
     steps:
     - checkout: self
       clean: true

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -39,7 +39,7 @@ extends:
       codeSignValidation:
         enabled: true
         break: true
-        tdl: $(System.DefaultWorkingDirectory)\pack
+        td1: $(System.DefaultWorkingDirectory)\pack
         targetPathExclusionPattern: \"**\*.xml\"
         ${{ if not(and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
           policyFile: $(MBSIGN_APPFOLDER)\CSVTestSignPolicy.xml

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -39,7 +39,6 @@ extends:
       codeSignValidation:
         enabled: true
         break: true
-        td1: $(System.DefaultWorkingDirectory)\pack
         targetPathExclusionPattern: \"**\*.xml\"
         ${{ if not(and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
           policyFile: $(MBSIGN_APPFOLDER)\CSVTestSignPolicy.xml

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -39,6 +39,10 @@ extends:
       codeSignValidation:
         enabled: true
         break: true
+        tdl: $(System.DefaultWorkingDirectory)\pack
+        targetPathExclusionPattern: \"**\*.xml\"
+        ${{ if not(and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
+          policyFile: $(MBSIGN_APPFOLDER)\CSVTestSignPolicy.xml
       sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
     pool:
       name: AzurePipelines-EO

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -37,7 +37,6 @@ extends:
         enabled: true
         exclusionsFile: $(Build.SourcesDirectory)\build\PoliCheckExclusions.xml
       codeSignValidation:
-        enabled: true
         break: true
         targetPathExclusionPattern: \"**\*.xml\"
         ${{ if not(and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -36,6 +36,9 @@ extends:
       policheck:
         enabled: true
         exclusionsFile: $(Build.SourcesDirectory)\build\PoliCheckExclusions.xml
+      codeSignValidation:
+        enabled: true
+        break: true
       sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
     pool:
       name: AzurePipelines-EO


### PR DESCRIPTION
## Description
Enabling code signing validation in the main mqtt pipeline.  Per guidance from Trevor Short, we're intentionally leaving in the existing call to the MicroBuildCodesignVerify task.

See https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/codesignvalidation

Part of task https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2268473

## PR Checklist
- [x] Title is meaningful
- [x] Work Item is linked
- [x] Changes are described

- **Tests**
  - [ ] Automated tests are added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] N/A: Infrastructure
  - **OR**
  - [ ] Upcoming sprint Work Item: <!-- link -->
  - **OR**
  - [ ] Test exception <!-- include short explanation -->
